### PR TITLE
Fix URL to coveralls badge.svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Apache Commons RDF (Incubating)
 
-[![Build Status](https://travis-ci.org/apache/incubator-commonsrdf.svg?branch=master)](https://travis-ci.org/apache/incubator-commonsrdf) [![Coverage Status](https://coveralls.io/r/apache/incubator-commonsrdf/badge.svg)](https://coveralls.io/r/apache/incubator-commonsrdf)
+[![Build Status](https://travis-ci.org/apache/incubator-commonsrdf.svg?branch=master)](https://travis-ci.org/apache/incubator-commonsrdf)
+[![Coverage Status](https://coveralls.io/repos/apache/incubator-commonsrdf/badge.svg)](https://coveralls.io/r/apache/incubator-commonsrdf)
 
 Commons RDF aims to provide a common library for [RDF 1.1](http://www.w3.org/TR/rdf11-concepts/) 
 that could be implemented by the upcoming versions of the main Java toolkits 


### PR DESCRIPTION
The badge URL is pointing to https://coveralls.io/r/apache/incubator-commonsrdf/badge.svg which is wrong. It has to be https://coveralls.io/repos/apache/incubator-commonsrdf/badge.svg.