### PR TITLE
COMMONSRDF-11 make simple subclassable

### DIFF
--- a/simple/src/main/java/org/apache/commons/rdf/simple/BlankNodeImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/BlankNodeImpl.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * A simple implementation of BlankNode.
  */
-final class BlankNodeImpl implements BlankNode {
+public class BlankNodeImpl implements BlankNode {
 
     private static AtomicLong bnodeCounter = new AtomicLong();
 

--- a/simple/src/main/java/org/apache/commons/rdf/simple/BlankNodeImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/BlankNodeImpl.java
@@ -43,7 +43,7 @@ final class BlankNodeImpl implements BlankNode {
         if (Objects.requireNonNull(id).isEmpty()) {
             throw new IllegalArgumentException("Invalid blank node id: " + id);
         }
-        String uuidInput = uuidSalt.toString() + ":" + id;
+        String uuidInput = System.identityHashCode(uuidSalt) + ":" + id;
         // Both the scope and the id are used to create the UUID, ensuring that
         // a caller can reliably create the same bnode if necessary by sending
         // in the same scope.

--- a/simple/src/main/java/org/apache/commons/rdf/simple/GraphImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/GraphImpl.java
@@ -33,13 +33,13 @@ import java.util.stream.Stream;
  * <p>
  * All Stream operations are performed using parallel and unordered directives.
  */
-final class GraphImpl implements Graph {
+public class GraphImpl implements Graph {
 
     private static final int TO_STRING_MAX = 10;
     private final Set<Triple> triples = new HashSet<Triple>();
     private final SimpleRDFTermFactory factory;
 
-    GraphImpl(SimpleRDFTermFactory simpleRDFTermFactory) {
+    public GraphImpl(SimpleRDFTermFactory simpleRDFTermFactory) {
         this.factory = simpleRDFTermFactory;
     }
 

--- a/simple/src/main/java/org/apache/commons/rdf/simple/IRIImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/IRIImpl.java
@@ -24,7 +24,7 @@ import java.net.URI;
 /**
  * A simple implementation of IRI.
  */
-final class IRIImpl implements IRI {
+public class IRIImpl implements IRI {
 
     private final String iri;
 

--- a/simple/src/main/java/org/apache/commons/rdf/simple/LiteralImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/LiteralImpl.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 /**
  * A simple implementation of Literal.
  */
-final class LiteralImpl implements Literal {
+public class LiteralImpl implements Literal {
 
     private static final String QUOTE = "\"";
 

--- a/simple/src/main/java/org/apache/commons/rdf/simple/TripleImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/TripleImpl.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * A simple implementation of Triple.
  */
-final class TripleImpl implements Triple {
+public class TripleImpl implements Triple {
 
     private final BlankNodeOrIRI subject;
     private final IRI predicate;

--- a/simple/src/test/java/org/apache/commons/rdf/simple/subclassable/SubClassRDFTermFactoryTest.java
+++ b/simple/src/test/java/org/apache/commons/rdf/simple/subclassable/SubClassRDFTermFactoryTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.simple.subclassable;
+
+import org.apache.commons.rdf.api.AbstractRDFTermFactoryTest;
+import org.apache.commons.rdf.api.BlankNode;
+import org.apache.commons.rdf.api.BlankNodeOrIRI;
+import org.apache.commons.rdf.api.Graph;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Literal;
+import org.apache.commons.rdf.api.RDFTerm;
+import org.apache.commons.rdf.api.RDFTermFactory;
+import org.apache.commons.rdf.api.Triple;
+import org.apache.commons.rdf.simple.BlankNodeImpl;
+import org.apache.commons.rdf.simple.GraphImpl;
+import org.apache.commons.rdf.simple.IRIImpl;
+import org.apache.commons.rdf.simple.LiteralImpl;
+import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
+import org.apache.commons.rdf.simple.TripleImpl;
+
+/**
+ * Test that all classes in simple can be extended by subclasses (in a different
+ * package).
+ *
+ */
+public class SubClassRDFTermFactoryTest extends AbstractRDFTermFactoryTest {
+
+    @Override
+    public RDFTermFactory createFactory() {
+        return new SubClassRDFTermFactory();
+    }
+
+    private class SubClassRDFTermFactory extends SimpleRDFTermFactory {
+        @Override
+        public BlankNode createBlankNode() {
+            return new BlankNodeImpl() {
+            };
+        }
+
+        @Override
+        public BlankNode createBlankNode(String identifier)
+                throws UnsupportedOperationException {
+            return new BlankNodeImpl(this, identifier) {
+            };
+        }
+
+        @Override
+        public Graph createGraph() throws UnsupportedOperationException {
+            return new GraphImpl(this) {
+            };
+        }
+
+        @Override
+        public Literal createLiteral(String literal) {
+            return new LiteralImpl(literal) {
+            };
+        }
+
+        @Override
+        public Literal createLiteral(String lexicalForm, IRI dataType) {
+            return new LiteralImpl(lexicalForm, dataType) {
+            };
+        }
+
+        @Override
+        public Literal createLiteral(String literal, String language) {
+            return new LiteralImpl(literal, language) {
+            };
+        }
+
+        @Override
+        public IRI createIRI(String iri) {
+            return new IRIImpl(iri) {
+            };
+        }
+
+        @Override
+        public Triple createTriple(BlankNodeOrIRI subject, IRI predicate,
+                RDFTerm object) {
+            return new TripleImpl(subject, predicate, object) {
+            };
+        }
+    }
+}


### PR DESCRIPTION
Fixes [COMMONSRDF-11](https://issues.apache.org/jira/browse/COMMONSRDF-11) by making all simple classes (except `Types`) non-`final` and have `public` constructors.

A new `SubClassRDFTermFactoryTest` verifies this by constructing each of them as an empty, anonymous subclass. (although it does not try to override any of their methods).