### PR TITLE
COMMONSRDF-12 Graph implements Iterable interface

### DIFF
--- a/api/src/main/java/org/apache/commons/rdf/api/Graph.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Graph.java
@@ -154,7 +154,7 @@ public interface Graph extends AutoCloseable {
      * <p>
      * This method is meant to be used with a Java for-each loop, e.g.: 
      * <code>
-     *  for (Triple t : GraphUtil.iterate(graph)) {
+     *  for (Triple t : graph.iterate()) {
      *      System.out.println(t);
      *  }
      * </code>
@@ -183,5 +183,48 @@ public interface Graph extends AutoCloseable {
     default Iterable<Triple> iterate() 
             throws ConcurrentModificationException, IllegalStateException {
         return ((Stream<Triple>)getTriples())::iterator;
+    }
+    
+    /**
+     * Get an Iterable for iterating over the triples in the graph that
+     * match the pattern. 
+     * <p>
+     * This method is meant to be used with a Java for-each loop, e.g.: 
+     * <code>
+     *  IRI alice = factory.createIRI("http://example.com/alice");
+     *  IRI knows = factory.createIRI("http://xmlns.com/foaf/0.1/");
+     *  for (Triple t : graph.iterate(alice, knows, null)) {
+     *      System.out.println(t.getObject());
+     *  }
+     * </code>
+     * The behaviour of the iterator is not specified if {@link #add(Triple)},
+     * {@link #remove(Triple)} or {@link #clear()}, are called on the
+     * {@link Graph} before it terminates. It is undefined if the returned
+     * {@link Iterator} supports the {@link Iterator#remove()} method.
+     * <p>
+     * Implementations may throw {@link ConcurrentModificationException} from
+     * Iterator methods if they detect a concurrency conflict while the Iterator
+     * is active.
+     * <p>
+     * The {@link Iterable#iterator()} must only be called once, that is the
+     * Iterable must only be iterated over once. A {@link IllegalStateException}
+     * may be thrown on attempt to reuse the Iterable.
+     *
+     * @param subject   The triple subject (null is a wildcard)
+     * @param predicate The triple predicate (null is a wildcard)
+     * @param object    The triple object (null is a wildcard)
+     * @return A {@link Iterable} that returns {@link Iterator} over the
+     *         matching triples in the graph
+     * @throws IllegalStateException
+     *             if the {@link Iterable} has been reused
+     * @throws ConcurrentModificationException
+     *             if a concurrency conflict occurs while the Iterator is
+     *             active.
+     */
+    @SuppressWarnings("unchecked")
+    default Iterable<Triple> iterate(
+            BlankNodeOrIRI subject, IRI predicate, RDFTerm object) 
+        throws ConcurrentModificationException, IllegalStateException {
+        return ((Stream<Triple>) getTriples(subject, predicate, object))::iterator;
     }
 }

--- a/api/src/main/java/org/apache/commons/rdf/api/Graph.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Graph.java
@@ -17,6 +17,7 @@
  */
 package org.apache.commons.rdf.api;
 
+import java.util.Iterator;
 import java.util.stream.Stream;
 
 /**
@@ -25,7 +26,7 @@ import java.util.stream.Stream;
  * href="http://www.w3.org/TR/rdf11-concepts/" >RDF-1.1 Concepts and Abstract
  * Syntax</a>, a W3C Recommendation published on 25 February 2014.
  */
-public interface Graph extends AutoCloseable {
+public interface Graph extends AutoCloseable,Iterable<Triple> {
 
     /**
      * Add a triple to the graph, possibly mapping any of the components of the
@@ -146,4 +147,26 @@ public interface Graph extends AutoCloseable {
      */
     Stream<? extends Triple> getTriples(BlankNodeOrIRI subject, IRI predicate,
                                         RDFTerm object);
+
+    /**
+     * Get an iterator for all triples contained by the graph.
+     * <p>
+     * The iteration SHOULD NOT contain any duplicate triples, as determined by
+     * the equals method for each {@link Triple}.
+     * <p>
+     * The behaviour of the iterator is not specified if add, remove, or clear,
+     * are called on the Graph before it terminates. It is undefined if the
+     * returned Iterator supports the remove method.
+     * <p>
+     * Implementations may throw ConcurrentModificationException from Iterator
+     * methods if they detect a concurrency conflict while the Iterator is
+     * active.
+     *
+     * @return A {@link Iterator} over all of the triples in the graph
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    default Iterator<Triple> iterator() {
+        return (Iterator<Triple>) getTriples().iterator();
+    }
 }

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -17,13 +17,18 @@
  */
 package org.apache.commons.rdf.api;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Optional;
-
-import static org.junit.Assert.*;
 
 /**
  * Test Graph implementation
@@ -132,6 +137,36 @@ public abstract class AbstractGraphTest {
                 companyName, bobNameTriple);
         // Can only reliably predict size if we could create all triples
         assertEquals(8, graph.size());
+    }
+
+    @Test
+    public void iterable() throws Exception {
+
+        Assume.assumeTrue(graph.size() > 0);
+
+        List<Triple> triples = new ArrayList<>();
+        for (Triple t : graph) {
+            triples.add(t);
+        }
+        assertEquals(graph.size(), (long)triples.size());
+        if (bobNameTriple != null) {
+            assertTrue(triples.contains(bobNameTriple));
+        }
+
+        // aborted iteration
+        Iterator<Triple> it = graph.iterator();
+
+        assertTrue(it.hasNext());
+        it.next();
+
+        // second iteration - should start from fresh and
+        // get the same count
+        long count = 0;
+        for (Triple t : graph) {
+            count++;
+        }
+        assertEquals(graph.size(), count);
+
     }
 
     @Test

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -17,9 +17,7 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -145,7 +143,7 @@ public abstract class AbstractGraphTest {
         Assume.assumeTrue(graph.size() > 0);
 
         List<Triple> triples = new ArrayList<>();
-        for (Triple t : graph) {
+        for (Triple t : graph.iterate()) {
             triples.add(t);
         }
         assertEquals(graph.size(), (long)triples.size());
@@ -154,7 +152,7 @@ public abstract class AbstractGraphTest {
         }
 
         // aborted iteration
-        Iterator<Triple> it = graph.iterator();
+        Iterator<Triple> it = graph.iterate().iterator();
 
         assertTrue(it.hasNext());
         it.next();
@@ -162,13 +160,13 @@ public abstract class AbstractGraphTest {
         // second iteration - should start from fresh and
         // get the same count
         long count = 0;
-        for (Triple t : graph) {
+        Iterable<Triple> iterable = graph.iterate();
+        for (Triple t : iterable) {
             count++;
         }
         assertEquals(graph.size(), count);
-
     }
-
+    
     @Test
     public void contains() throws Exception {
         assertFalse(graph.contains(bob, knows, alice)); // or so he claims..

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -138,7 +138,7 @@ public abstract class AbstractGraphTest {
     }
 
     @Test
-    public void iterable() throws Exception {
+    public void iterate() throws Exception {
 
         Assume.assumeTrue(graph.size() > 0);
 
@@ -165,6 +165,21 @@ public abstract class AbstractGraphTest {
             count++;
         }
         assertEquals(graph.size(), count);
+    }
+    
+    @Test
+    public void iterateFilter() throws Exception {
+        List<RDFTerm> friends = new ArrayList<>();
+        IRI alice = factory.createIRI("http://example.com/alice");
+        IRI knows = factory.createIRI("http://xmlns.com/foaf/0.1/knows");
+        for (Triple t : graph.iterate(alice, knows, null)) {
+            friends.add(t.getObject());
+        }
+        assertEquals(1, friends.size());
+        assertEquals(bob, friends.get(0));
+        
+        // .. can we iterate over zero hits?
+        assertFalse(graph.iterate(bob, knows, alice).iterator().hasNext());
     }
     
     @Test


### PR DESCRIPTION
..with a `default` method that simply calls `getTriples().iterator()`

This is mainly to be useful for classical for-each loops in Java.

Fixes [COMMONSRDF-12](https://issues.apache.org/jira/browse/COMMONSRDF-12)