### PR TITLE
COMMONSRDF-12 GraphUtils.iterate function

### DIFF
--- a/api/src/main/java/org/apache/commons/rdf/api/Graph.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Graph.java
@@ -17,6 +17,7 @@
  */
 package org.apache.commons.rdf.api;
 
+import java.util.Iterator;
 import java.util.stream.Stream;
 
 /**
@@ -25,7 +26,7 @@ import java.util.stream.Stream;
  * href="http://www.w3.org/TR/rdf11-concepts/" >RDF-1.1 Concepts and Abstract
  * Syntax</a>, a W3C Recommendation published on 25 February 2014.
  */
-public interface Graph extends AutoCloseable {
+public interface Graph extends AutoCloseable,Iterable<Triple> {
 
     /**
      * Add a triple to the graph, possibly mapping any of the components of the
@@ -146,4 +147,26 @@ public interface Graph extends AutoCloseable {
      */
     Stream<? extends Triple> getTriples(BlankNodeOrIRI subject, IRI predicate,
                                         RDFTerm object);
+
+    /**
+     * Get an iterator for all triples contained by the graph.
+     * <p>
+     * The iteration SHOULD NOT contain any duplicate triples, as determined by
+     * the equals method for each {@link Triple}.
+     * <p>
+     * The behaviour of the iterator is not specified if add, remove, or clear,
+     * are called on the Graph before it terminates. It is undefined if the
+     * returned Iterator supports the remove method.
+     * <p>
+     * Implementations may throw ConcurrentModificationException from Iterator
+     * methods if they detect a concurrency conflict while the Iterator is
+     * active.
+     *
+     * @return A {@link Iterator} over all of the triples in the graph
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    default Iterator<Triple> iterator() {
+        return (Iterator<Triple>) getTriples().iterator();
+    }
 }

--- a/api/src/main/java/org/apache/commons/rdf/api/Graph.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Graph.java
@@ -17,7 +17,6 @@
  */
 package org.apache.commons.rdf.api;
 
-import java.util.Iterator;
 import java.util.stream.Stream;
 
 /**
@@ -26,7 +25,7 @@ import java.util.stream.Stream;
  * href="http://www.w3.org/TR/rdf11-concepts/" >RDF-1.1 Concepts and Abstract
  * Syntax</a>, a W3C Recommendation published on 25 February 2014.
  */
-public interface Graph extends AutoCloseable,Iterable<Triple> {
+public interface Graph extends AutoCloseable {
 
     /**
      * Add a triple to the graph, possibly mapping any of the components of the
@@ -148,25 +147,4 @@ public interface Graph extends AutoCloseable,Iterable<Triple> {
     Stream<? extends Triple> getTriples(BlankNodeOrIRI subject, IRI predicate,
                                         RDFTerm object);
 
-    /**
-     * Get an iterator for all triples contained by the graph.
-     * <p>
-     * The iteration SHOULD NOT contain any duplicate triples, as determined by
-     * the equals method for each {@link Triple}.
-     * <p>
-     * The behaviour of the iterator is not specified if add, remove, or clear,
-     * are called on the Graph before it terminates. It is undefined if the
-     * returned Iterator supports the remove method.
-     * <p>
-     * Implementations may throw ConcurrentModificationException from Iterator
-     * methods if they detect a concurrency conflict while the Iterator is
-     * active.
-     *
-     * @return A {@link Iterator} over all of the triples in the graph
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    default Iterator<Triple> iterator() {
-        return (Iterator<Triple>) getTriples().iterator();
-    }
 }

--- a/api/src/main/java/org/apache/commons/rdf/api/GraphUtil.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/GraphUtil.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.api;
+
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * Utility functions for working with {@link Graph}s.
+ *
+ */
+public class GraphUtil {
+    /**
+     * Get an Iterable for iterating over all triples in the graph.
+     * <p>
+     * This method is meant to be used with a classical Java for-each loop, e.g.:
+     * <code>
+     *  for (Triple t : GraphUtil.iterate(graph)) {
+            System.out.println(t);
+        }
+     * </code>
+     * <p>
+     * The behaviour of the iterator is not specified if add, remove, or clear,
+     * are called on the Graph before it terminates. It is undefined if the
+     * returned Iterator supports the remove method.
+     * <p>
+     * Implementations may throw ConcurrentModificationException from Iterator
+     * methods if they detect a concurrency conflict while the Iterator is
+     * active.
+     *
+     * @param graph The {@link Graph} which triples are to be iterated over
+     * @return A {@link Iterable} that returns {@link Iterator} over all of the triples in the graph
+     * 
+     */  
+    public static Iterable<Triple> iterate(final Graph graph) {
+        return new Iterable<Triple>() {            
+            @SuppressWarnings("unchecked")
+            @Override
+            public Iterator<Triple> iterator() {
+                return (Iterator<Triple>) graph.getTriples().iterator();
+            }
+        };
+    }
+
+    /**
+     * Get an Iterable for iterating over all triples in the Stream of Triples.
+     * <p>
+     * This method is meant to be used with a classical Java for-each loop
+     * together with {@link Graph#getTriples(BlankNodeOrIRI, IRI, RDFTerm)},
+     * e.g.: <code>
+     *  IRI s1, p1; // ...   
+     *  for (Triple t : GraphUtil.iterate(graph.getTriples(s1, p1, null)) {
+     *      System.out.println(t.getObject());
+     *  }
+     * </code>
+     * <p>
+     * The behaviour of the iterator is not specified if add, remove, or clear,
+     * are called on the Graph before it terminates. It is undefined if the
+     * returned Iterator supports the remove method.
+     * <p>
+     * Implementations may throw ConcurrentModificationException from Iterator
+     * methods if they detect a concurrency conflict while the Iterator is
+     * active.
+     * <p>
+     * As {@link Stream#iterator()} is a terminal operation, this method should
+     * only be used once on a stream, and its {@link Iterable#iterator()} must
+     * only be iterated over once. A IllegalStateException is thrown on attempt
+     * to reuse a stream or Iterable.
+     *
+     * @param graph
+     *            The {@link Graph} which triples are to be iterated over
+     * @return A {@link Iterable} that returns {@link Iterator} over all of the
+     *         triples in the graph
+     * @throws IllegalStateException
+     *             if the {@link Stream} or the {@link Iterable} has been reused
+     */      
+    public static Iterable<Triple> iterate(Stream<? extends Triple> triples) throws IllegalStateException {
+        return new Iterable<Triple>() {           
+            @SuppressWarnings("unchecked")
+            @Override
+            public Iterator<Triple> iterator() {
+                return (Iterator<Triple>) triples.iterator();
+            }
+        };
+    }
+}

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -17,13 +17,18 @@
  */
 package org.apache.commons.rdf.api;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Optional;
-
-import static org.junit.Assert.*;
 
 /**
  * Test Graph implementation
@@ -132,6 +137,36 @@ public abstract class AbstractGraphTest {
                 companyName, bobNameTriple);
         // Can only reliably predict size if we could create all triples
         assertEquals(8, graph.size());
+    }
+
+    @Test
+    public void iterable() throws Exception {
+
+        Assume.assumeTrue(graph.size() > 0);
+
+        List<Triple> triples = new ArrayList<>();
+        for (Triple t : graph) {
+            triples.add(t);
+        }
+        assertEquals(graph.size(), (long)triples.size());
+        if (bobNameTriple != null) {
+            assertTrue(triples.contains(bobNameTriple));
+        }
+
+        // aborted iteration
+        Iterator<Triple> it = graph.iterator();
+
+        assertTrue(it.hasNext());
+        it.next();
+
+        // second iteration - should start from fresh and
+        // get the same count
+        long count = 0;
+        for (Triple t : graph) {
+            count++;
+        }
+        assertEquals(graph.size(), count);
+
     }
 
     @Test

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -20,11 +20,13 @@ package org.apache.commons.rdf.api;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.junit.Assume;
 import org.junit.Before;
@@ -145,7 +147,7 @@ public abstract class AbstractGraphTest {
         Assume.assumeTrue(graph.size() > 0);
 
         List<Triple> triples = new ArrayList<>();
-        for (Triple t : graph) {
+        for (Triple t : GraphUtil.iterate(graph)) {
             triples.add(t);
         }
         assertEquals(graph.size(), (long)triples.size());
@@ -154,7 +156,7 @@ public abstract class AbstractGraphTest {
         }
 
         // aborted iteration
-        Iterator<Triple> it = graph.iterator();
+        Iterator<Triple> it = GraphUtil.iterate(graph).iterator();
 
         assertTrue(it.hasNext());
         it.next();
@@ -162,13 +164,59 @@ public abstract class AbstractGraphTest {
         // second iteration - should start from fresh and
         // get the same count
         long count = 0;
-        for (Triple t : graph) {
+        for (Triple t : GraphUtil.iterate(graph)) {
             count++;
         }
         assertEquals(graph.size(), count);
 
     }
 
+    @Test
+    public void iterableStream() throws Exception {
+
+        Assume.assumeTrue(graph.size() > 0);
+
+        List<RDFTerm> objects = new ArrayList<>();
+        for (Triple t : GraphUtil.iterate(graph.getTriples(alice, knows, null))) {
+            objects.add(t.getObject());
+        }
+        assertEquals(1, objects.size());
+        assertEquals(bob, objects.get(0));
+        
+        // aborted iteration
+        Iterator<Triple> it = GraphUtil.iterate(graph.getTriples(alice, knows, null)).iterator();
+
+        assertTrue(it.hasNext());
+        it.next();
+
+        // second iteration - should start from fresh and
+        // get the same count
+        long count = 0;
+        Stream<? extends Triple> stream = graph.getTriples(alice, knows, null);
+        for (Triple t : GraphUtil.iterate(stream)) {
+            count++;
+        }
+        assertEquals(1, count);
+        
+
+    }
+    
+    @Test(expected=IllegalStateException.class)
+    public void iterableStreamTwiceFails() throws Exception {
+        Stream<? extends Triple> stream = graph.getTriples(alice, knows, null);
+        long count = 0;
+        for (Triple t : GraphUtil.iterate(stream)) {
+            count++;
+        }
+        assertEquals(1, count);
+        // Can't iterate again over terminated stream, below should
+        // throw IllegalStateException
+        for (Triple t : GraphUtil.iterate(stream)) {
+            fail("Should not be able to iterate on a finished stream");
+        }
+    }
+
+    
     @Test
     public void contains() throws Exception {
         assertFalse(graph.contains(bob, knows, alice)); // or so he claims..


### PR DESCRIPTION
Alternative to pull request #8  for implementing [COMMONSRDF-12](https://issues.apache.org/jira/browse/COMMONSRDF-12) without modifying `Graph`.

This adds a new `GraphUtils` to `api`  (or should it be in `simple`?) which has two static `iterate()` methods.

Usage:
```
        for (Triple t : GraphUtil.iterate(graph)) {
            System.out.println(t);
        }

        for (Triple t : GraphUtil.iterate(graph.getTriples(alice, knows, null))) {
            System.out.println(t.getObject());
        }
```

