### PR TITLE
Use constants defined on StandardCharsets

### DIFF
--- a/examples/src/example/UserGuideTest.java
+++ b/examples/src/example/UserGuideTest.java
@@ -214,6 +214,6 @@ public class UserGuideTest {
 
 	public static void writeGraph(Graph graph, Path graphFile) throws Exception {
         Stream<CharSequence> stream = graph.getTriples().map(UserGuideTest::tripleAsString);
-        Files.write(graphFile, stream::iterator, Charset.forName("UTF-8"));
+        Files.write(graphFile, stream::iterator, StandardCharsets.UTF_8);
 	}
 }

--- a/simple/src/test/java/org/apache/commons/rdf/simple/TestWritingGraph.java
+++ b/simple/src/test/java/org/apache/commons/rdf/simple/TestWritingGraph.java
@@ -20,6 +20,7 @@ package org.apache.commons.rdf.simple;
 import static org.junit.Assert.assertEquals;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -123,7 +124,7 @@ public class TestWritingGraph {
         }
 
         Stream<CharSequence> stream = graph.getTriples().map(TestWritingGraph::tripleAsString);
-        Files.write(graphFile, stream::iterator, Charset.forName("UTF-8"));
+        Files.write(graphFile, stream::iterator, StandardCharsets.UTF_8);
     }
 
     @Test
@@ -139,7 +140,7 @@ public class TestWritingGraph {
         IRI predicate = factory.createIRI("pred");
         Stream<CharSequence> stream = graph
                 .getTriples(subject, predicate, null).map(TestWritingGraph::tripleAsString);
-        Files.write(graphFile, stream::iterator, Charset.forName("UTF-8"));
+        Files.write(graphFile, stream::iterator, StandardCharsets.UTF_8);
 
     }
 
@@ -156,7 +157,7 @@ public class TestWritingGraph {
         IRI predicate = factory.createIRI("pred");
         Stream<CharSequence> stream = graph
                 .getTriples(subject, predicate, null).map(Object::toString);
-        Files.write(graphFile, stream::iterator, Charset.forName("UTF-8"));
+        Files.write(graphFile, stream::iterator, StandardCharsets.UTF_8);
 
     }
 

--- a/src/site/markdown/userguide.md.vm
+++ b/src/site/markdown/userguide.md.vm
@@ -231,7 +231,7 @@ public class NTriplesSerializer {
     }
     public static void writeGraph(Graph graph, Path graphFile) throws Exception {
         Stream<CharSequence> stream = graph.getTriples().map(NTriplesSerializer::tripleAsString);
-        Files.write(graphFile, stream::iterator, Charset.forName("UTF-8"));
+        Files.write(graphFile, stream::iterator, StandardCharsets.UTF_8);
     }
 }
 ```


### PR DESCRIPTION
Java 7 introduced constants for the Charsets which should be available on every JVM. Use constants defined on StandardCharsets instead of retrieving Charsets by name.