### PR TITLE
COMMONSRDF-20: Provide a mechanism for allowing the load of different RDF Term Factories

### DIFF
--- a/simple/src/main/resources/META-INF/services/org.apache.commons.rdf.api.RDFTermFactory
+++ b/simple/src/main/resources/META-INF/services/org.apache.commons.rdf.api.RDFTermFactory
@@ -1,0 +1,1 @@
+org.apache.commons.rdf.simple.SimpleRDFTermFactory

--- a/simple/src/test/java/org/apache/commons/rdf/simple/SimpleRDFTermFactoryLookupTest.java
+++ b/simple/src/test/java/org/apache/commons/rdf/simple/SimpleRDFTermFactoryLookupTest.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rdf.simple;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+import org.apache.commons.rdf.api.RDFTermFactory;
+import org.junit.Test;
+
+public class SimpleRDFTermFactoryLookupTest {
+
+    @Test
+    public void testServiceLoaderLookup() {
+        ServiceLoader<RDFTermFactory> loader = ServiceLoader.load(RDFTermFactory.class);
+
+        Iterator<RDFTermFactory> iterator = loader.iterator();
+        RDFTermFactory factory = iterator.next();
+
+        assertTrue(factory instanceof SimpleRDFTermFactory);
+        assertFalse(iterator.hasNext());
+    }
+}

--- a/src/site/markdown/userguide.md.vm
+++ b/src/site/markdown/userguide.md.vm
@@ -148,9 +148,9 @@ import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
 RDFTermFactory factory = new SimpleRDFTermFactory();
 ```
 
-If you don't want to depend up the concret implementation you can use a
+If you don't want to depend up the concrete implementation you can use a
 [ServiceLoader](http://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html)
-to lookup instances:
+to lookup any implementations found on the classpath:
 
 ```java
 import java.util.Iterator;

--- a/src/site/markdown/userguide.md.vm
+++ b/src/site/markdown/userguide.md.vm
@@ -148,6 +148,21 @@ import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
 RDFTermFactory factory = new SimpleRDFTermFactory();
 ```
 
+If you don't want to depend up the concret implementation you can use a
+[ServiceLoader](http://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html)
+to lookup instances:
+
+```java
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+import org.apache.commons.rdf.api.*;
+// ...
+ServiceLoader<RDFTermFactory> loader = ServiceLoader.load(RDFTermFactory.class);
+Iterator<RDFTermFactory> iterator = loader.iterator();
+RDFTermFactory factory = iterator.next();
+```
+
 Using the factory you can construct
 any [RDFTerm](apidocs/org/apache/commons/rdf/api/RDFTerm.html), e.g. to create a
 [BlankNode](apidocs/org/apache/commons/rdf/api/BlankNode.html),


### PR DESCRIPTION
As discussed in [COMMONSRDF-20](https://issues.apache.org/jira/browse/COMMONSRDF-20) here is a PR adding the possibility to use a ```ServiceLoader``` for looking up RDFTermFactory instances.