### PR TITLE
COMMONSRDF-14 define explicit hashCode

### DIFF
--- a/api/src/main/java/org/apache/commons/rdf/api/BlankNode.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/BlankNode.java
@@ -105,7 +105,7 @@ public interface BlankNode extends BlankNodeOrIRI {
      * The returned hash code MUST be equal to the
      * {@link String#hashCode()} of the
      * {@link #uniqueReference()}.
-     *
+     * <p>
      * This method MUST be implemented in conjunction with
      * {@link #equals(Object)} so that two equal BlankNodes produce the same
      * hash code.

--- a/api/src/main/java/org/apache/commons/rdf/api/BlankNode.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/BlankNode.java
@@ -101,6 +101,10 @@ public interface BlankNode extends BlankNodeOrIRI {
 
     /**
      * Calculate a hash code for this BlankNode.
+     * <p>
+     * The returned hash code MUST be equal to the
+     * {@link String#hashCode()} of the
+     * {@link #uniqueReference()}.
      *
      * This method MUST be implemented in conjunction with
      * {@link #equals(Object)} so that two equal BlankNodes produce the same

--- a/api/src/main/java/org/apache/commons/rdf/api/IRI.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/IRI.java
@@ -64,7 +64,7 @@ public interface IRI extends BlankNodeOrIRI {
      * The returned hash code MUST be equal to the
      * {@link String#hashCode()} of the
      * {@link #getIRIString()}.
-     *
+     * <p>
      * This method MUST be implemented in conjunction with
      * {@link #equals(Object)}
      * so that two equal IRIs produce the same hash code.

--- a/api/src/main/java/org/apache/commons/rdf/api/IRI.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/IRI.java
@@ -60,8 +60,13 @@ public interface IRI extends BlankNodeOrIRI {
 
     /**
      * Calculate a hash code for this IRI.
+     * <p>
+     * The returned hash code MUST be equal to the
+     * {@link String#hashCode()} of the
+     * {@link #getIRIString()}.
      *
-     * This method MUST be implemented when implementing {@link #equals(Object)}
+     * This method MUST be implemented in conjunction with
+     * {@link #equals(Object)}
      * so that two equal IRIs produce the same hash code.
      *
      * @return a hash code value for this IRI.

--- a/api/src/main/java/org/apache/commons/rdf/api/Literal.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Literal.java
@@ -18,6 +18,7 @@
 package org.apache.commons.rdf.api;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -106,12 +107,18 @@ public interface Literal extends RDFTerm {
 
     /**
      * Calculate a hash code for this Literal.
-     *
-     * This method MUST be implemented when implementing {@link #equals(Object)}
+     * <p>
+     * The returned hash code MUST be equal to the result
+     * of {@link Objects#hash(Object...)} with
+     * the arguments
+     * {@link #getLexicalForm()}, {@link #getDatatype()}, {@link #getLanguageTag()}.
+     * <p>
+     * This method MUST be implemented in conjunction with {@link #equals(Object)}
      * so that two equal Literals produce the same hash code.
      *
      * @return a hash code value for this Literal.
      * @see Object#hashCode()
+     * @see Objects#hash(Object...)
      */
     @Override
     public int hashCode();

--- a/api/src/main/java/org/apache/commons/rdf/api/Triple.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Triple.java
@@ -17,6 +17,8 @@
  */
 package org.apache.commons.rdf.api;
 
+import java.util.Objects;
+
 /**
  * An <a href= "http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple" >RDF-1.1
  * Triple</a>, as defined by <a href= "http://www.w3.org/TR/rdf11-concepts/"
@@ -85,12 +87,17 @@ public interface Triple {
     /**
      * Calculate a hash code for this Triple.
      * <p>
-     * This method MUST be implemented when implementing {@link #equals(Object)}
-     * so that two equal IRIs produce the same hash code.
-     * </p>
+     * The returned hash code MUST be equal to the result
+     * of {@link Objects#hash(Object...)} with
+     * the arguments
+     * {@link #getSubject()}, {@link #getPredicate()}, {@link #getObject()}.
+     * <p>
+     * This method MUST be implemented in conjunction with {@link #equals(Object)}
+     * so that two equal {@link Triple}s produce the same hash code.
      *
      * @return a hash code value for this Triple.
      * @see Object#hashCode()
+     * @see Objects#hash(Object...)
      */
     @Override
     public int hashCode();

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractRDFTermFactoryTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractRDFTermFactoryTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 
+import java.util.Objects;
+
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -406,4 +408,69 @@ public abstract class AbstractRDFTermFactoryTest {
         factory.createTriple(subject, (IRI) predicate, object);
     }
 
+    @Test
+    public void hashCodeBlankNode() throws Exception {
+        BlankNode bnode1;
+        try {
+            bnode1 = factory.createBlankNode();
+        } catch (UnsupportedOperationException ex) {
+            Assume.assumeNoException(
+                    "createBlankNode() not supported", ex);
+            return;
+        }
+        assertEquals(bnode1.uniqueReference().hashCode(), bnode1.hashCode());
+    }
+
+    @Test
+    public void hashCodeIRI() throws Exception {
+        IRI iri;
+        try {
+            iri = factory.createIRI("http://example.com/");
+        } catch (UnsupportedOperationException ex) {
+            Assume.assumeNoException(
+                    "createIRI(String) not supported", ex);
+            return;
+        }
+        assertEquals(iri.getIRIString().hashCode(), iri.hashCode());
+    }
+
+    @Test
+    public void hashCodeLiteral() throws Exception {
+        Literal literal;
+        try {
+            literal = factory.createLiteral("Hello");
+        } catch (UnsupportedOperationException ex) {
+            Assume.assumeNoException(
+                    "createLiteral(String) not supported", ex);
+            return;
+        }
+        assertEquals(Objects.hash(
+                    literal.getLexicalForm(),
+                    literal.getDatatype(),
+                    literal.getLanguageTag()
+                ),
+                literal.hashCode());
+    }
+
+    @Test
+    public void hashCodeTriple() throws Exception {
+        IRI iri;
+        try {
+            iri = factory.createIRI("http://example.com/");
+        } catch (UnsupportedOperationException ex) {
+            Assume.assumeNoException(
+                    "createIRI() not supported", ex);
+            return;
+        }
+        Triple triple;
+        try {
+            triple = factory.createTriple(iri, iri, iri);
+        } catch (UnsupportedOperationException ex) {
+            Assume.assumeNoException(
+                    "createTriple() not supported", ex);
+            return;
+        }
+        assertEquals(Objects.hash(iri, iri, iri),
+                     triple.hashCode());
+    }
 }

--- a/simple/src/main/java/org/apache/commons/rdf/simple/LiteralImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/LiteralImpl.java
@@ -17,13 +17,13 @@
  */
 package org.apache.commons.rdf.simple;
 
-import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.Literal;
-
 import java.util.IllformedLocaleException;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Literal;
 
 /**
  * A simple implementation of Literal.
@@ -117,7 +117,7 @@ final class LiteralImpl implements Literal {
 
     @Override
     public int hashCode() {
-        return Objects.hash(dataType, lexicalForm, languageTag);
+        return Objects.hash(lexicalForm, dataType, languageTag);
     }
 
     @Override


### PR DESCRIPTION
Fixes [COMMONSRDF-14](https://issues.apache.org/jira/browse/COMMONSRDF-14) by defining explicit `hashCode()` for `BlankNode`, `IRI`, `Literal` and `Triple`.

For comments on this pull request, please primarily use the Jira issue COMMONSRDF-14 thread, as GitHub email synchronization is not always working well.

Generated javadocs:

http://stain.github.io/incubator-commonsrdf/COMMONSRDF-14/org/apache/commons/rdf/api/BlankNode.html#hashCode--
http://stain.github.io/incubator-commonsrdf/COMMONSRDF-14/org/apache/commons/rdf/api/IRI.html#hashCode--
http://stain.github.io/incubator-commonsrdf/COMMONSRDF-14/org/apache/commons/rdf/api/Literal.html#hashCode--
http://stain.github.io/incubator-commonsrdf/COMMONSRDF-14/org/apache/commons/rdf/api/Triple.html#hashCode--

The approach I suggest here favours simplicity in the documentation - so `BlankNode` hashCode is equal to the String.hashCode() of its `uniqueReference()` without modifications, and likewise for `IRI` with `getUriString().hashCode()`:

>  The returned hash code MUST be equal to the String.hashCode() of the getIRIString(). 

.. while the compound objects are using [Objects.hash()](http://docs.oracle.com/javase/8/docs/api/java/util/Objects.html#hash-java.lang.Object...-):

>  The returned hash code MUST be equal to the result of Objects.hash(Object...) with the arguments getLexicalForm(), getDatatype(), getLanguageTag(). 

This means that our `hashCode()` definition does not need to define in detail how to combine these - but unfortunately `Objects.hash()` is also not explicit about this, so clients would then be forced to use Objects.hash(). They are not required to use the actual getter methods (e.g. LiteralImpl uses the private fields directly) - as long as the resulting hashCode is the same AS IF this had been done. Due to the direct mappings to the uniqueReference and IRI this means that a `TripleImpl` can take several shortcuts if it wants to. Combined with [COMMONSRDF-7](https://issues.apache.org/jira/browse/COMMONSRDF-7) for immutability the hashCode would stay the same for the duration of the object and can thus also be cached if so needed.

## Implementation notes:

[Optional.hashCode()](http://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#hashCode--) returns the hashCode of the value, or `0` if it is not present. 

(Warning: GPLv3 code links below!)

In OpenJDK 8, [Objects.hash](https://github.com/stain/jdk8u/blob/master/src/share/classes/java/util/Objects.java#L127) calls [Arrays.hashCode](https://github.com/stain/jdk8u/blob/master/src/share/classes/java/util/Arrays.java#L4118) which adds the hashCode with `31` as multiplier. This is however not explicit.