### PR TITLE
COMMONSRDF-25 Remove mentions of "local scope"

### DIFF
--- a/api/src/main/java/org/apache/commons/rdf/api/BlankNode.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/BlankNode.java
@@ -87,13 +87,12 @@ public interface BlankNode extends BlankNodeOrIRI {
      * Check it this BlankNode is equal to another BlankNode. Two BlankNodes
      * MUST be equal if, and only if, they have the same
      * {@link #uniqueReference()}.
-     *
+     * <p>
      * Implementations MUST also override {@link #hashCode()} so that two equal
      * Literals produce the same hash code.
      *
      * @param other Another object
-     * @return true if other is a BlankNode, is in the same local scope and is
-     * equal to this BlankNode
+     * @return true if other is a BlankNode instance that represent the same blank node
      * @see Object#equals(Object)
      */
     @Override

--- a/api/src/main/java/org/apache/commons/rdf/api/IRI.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/IRI.java
@@ -43,10 +43,8 @@ public interface IRI extends BlankNodeOrIRI {
      * normalization MUST NOT be performed when comparing IRIs for equality.
      * </blockquote>
      *
-     * Two IRIs are equal are in the same local scope and their
+     * Two IRI instances are equal if and only if their
      * {@link #getIRIString()} are equal.
-     *
-     * Implementations MAY check the local scope for IRI comparison.
      *
      * Implementations MUST also override {@link #hashCode()} so that two equal
      * IRIs produce the same hash code.

--- a/api/src/main/java/org/apache/commons/rdf/api/Literal.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Literal.java
@@ -92,8 +92,6 @@ public interface Literal extends RDFTerm {
      * literals can have the same value without being the same RDF term.
      * </blockquote>
      *
-     * Implementations MAY check the local scope for Literal comparison.
-     *
      * Implementations MUST also override {@link #hashCode()} so that two equal
      * Literals produce the same hash code.
      *

--- a/api/src/main/java/org/apache/commons/rdf/api/Triple.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Triple.java
@@ -66,11 +66,6 @@ public interface Triple {
      * {@link #getPredicate()} and {@link #getObject()} are equal.
      * </p>
      * <p>
-     * Implementations MUST check the local scope for Triple comparison if
-     * either the subject or object is a BlankNode, and MAY check the local
-     * scope in other cases.
-     * </p>
-     * <p>
      * Implementations MUST also override {@link #hashCode()} so that two equal
      * Triples produce the same hash code.
      * </p>


### PR DESCRIPTION
Fixes [COMMONSRDF-25](https://issues.apache.org/jira/browse/COMMONSRDF-25) by removing all "may check the local scope" texts within the `.equals()`

Only exception is in `BlankNode`, which keeps the text:

> Blank node identifiers are local identifiers that are used in some concrete RDF
> syntaxes or RDF store implementations. They are always
> <em>locally scoped</em> to the file or RDF store, and are <em>not</em>
>  persistent or portable identifiers for blank nodes.