### PR TITLE
COMMONSRDF-21 No BlankNode requirements in createGraph()

### DIFF
--- a/api/src/main/java/org/apache/commons/rdf/api/RDFTermFactory.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFTermFactory.java
@@ -91,11 +91,6 @@ public interface RDFTermFactory {
      * It is undefined if the graph will be persisted by any underlying storage
      * mechanism.
      *
-     * {@link BlankNode} objects added to the {@link Graph} returned from this
-     * method SHOULD be mapped using the {@link #createBlankNode(String)} of
-     * this factory, called using the {@link BlankNode#uniqueReference()} as
-     * the parameter, before they are inserted into the Graph.
-     *
      * @return A new Graph
      * @throws UnsupportedOperationException If the operation is not supported.
      */


### PR DESCRIPTION
Fixes [COMMONSRDF-21](https://issues.apache.org/jira/browse/COMMONSRDF-21) by removing the requirement for `BlankNode` mapping for the returned `Graph`'s `createGraph()`.