### PR TITLE
Coveralls API/plugin broke, requiring an update to the plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>


### PR DESCRIPTION
See logs on https://travis-ci.org/apache/incubator-commonsrdf for the error messages relating to this.