### PR TITLE
Add RDFSyntax, enumeration of RDF languages

### DIFF
--- a/api/src/main/java/org/apache/commons/rdf/api/RDFSyntax.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFSyntax.java
@@ -25,7 +25,8 @@ import java.util.Optional;
  * <p>
  * This enumeration lists the W3C standardized 
  * RDF 1.1 syntaxes like {@link #TURTLE} and {@link #JSONLD}.  
- * Note the existence of other RDF syntaxes that are not included here, e.g. <a href="http://www.w3.org/TeamSubmission/n3/">N3</a> 
+ * Note the existence of other RDF syntaxes that are not included here, 
+ * e.g. <a href="http://www.w3.org/TeamSubmission/n3/">N3</a> 
  * and <a href="https://en.wikipedia.org/wiki/TriX_%28syntax%29">TriX</a>.
  * 
  * @see <a href="https://www.w3.org/TR/rdf11-primer/#section-graph-syntax">RDF 1.1 Primer</a>
@@ -39,57 +40,57 @@ public enum RDFSyntax {
 	 * @see <a href="https://www.w3.org/TR/json-ld/">https://www.w3.org/TR/json-ld/</a>
 	 * 
 	 */
-	JSONLD("JSON-LD 1.0", "application/ld+json"),
+	JSONLD("JSON-LD 1.0", "application/ld+json", ".jsonld", true),
 
 	/**
 	 * RDF 1.1 Turtle
 	 * 
-	 * @see <a href="https://www.w3.org/TR/turtle/">RDF 1.1 Turtle</a>
+	 * @see <a href="https://www.w3.org/TR/turtle/">https://www.w3.org/TR/turtle/</a>
 	 *
 	 */
-	TURTLE("RDF 1.1 Turtle", "text/turtle"), 
+	TURTLE("RDF 1.1 Turtle", "text/turtle", ".ttl", false), 
 
 	/**
 	 * RDF 1.1 N-Quads
 	 * 
 	 * @see <a href="https://www.w3.org/TR/n-quads/">https://www.w3.org/TR/n-quads/</a>
 	 */
-	NQUADS("RDF 1.1 N-Quads", "application/n-quads"),
+	NQUADS("RDF 1.1 N-Quads", "application/n-quads", ".nq", true),
 
 	/**
 	 * RDF 1.1 N-Triples
 	 * 
 	 * @see <a href="https://www.w3.org/TR/n-triples/">https://www.w3.org/TR/n-triples/</a>
 	 */
-	NTRIPLES("RDF 1.1 N-Triples", "application/n-triples"),
+	NTRIPLES("RDF 1.1 N-Triples", "application/n-triples", ".nt", false),
 	
 	/**
 	 * HTML+RDFa 1.1
 	 * 
 	 * @see <a href="https://www.w3.org/TR/html-rdfa/">https://www.w3.org/TR/html-rdfa/</a>
 	 */
-	RDFA_HTML("HTML+RDFa 1.1", "text/html"),
+	RDFA_HTML("HTML+RDFa 1.1", "text/html", ".html", false),
 	
 	/**
 	 * XHTML+RDFa 1.1 
 	 * 
 	 * @see <a href="https://www.w3.org/TR/xhtml-rdfa/">https://www.w3.org/TR/xhtml-rdfa/</a> 
 	 */
-	RDFA_XHTML("XHTML+RDFa 1.1", "application/xhtml+xml"),
+	RDFA_XHTML("XHTML+RDFa 1.1", "application/xhtml+xml", ".xhtml", false),
 	
 	/**
 	 * RDF 1.1 XML Syntax
 	 * 
 	 * @see <a href="https://www.w3.org/TR/rdf-syntax-grammar/">https://www.w3.org/TR/rdf-syntax-grammar/</a>
 	 */
-	RDFXML("RDF 1.1 XML Syntax", "application/rdf+xml"),
+	RDFXML("RDF 1.1 XML Syntax", "application/rdf+xml", ".rdf", false),
 	
 	/**
 	 * RDF 1.1 TriG
 	 * 
 	 * @see <a href="https://www.w3.org/TR/trig/">https://www.w3.org/TR/trig/</a>
 	 */
-	TRIG("RDF 1.1 TriG", "application/trig");
+	TRIG("RDF 1.1 TriG", "application/trig", ".trig", true);
 
 	/** 
 	 * The <a href="https://tools.ietf.org/html/rfc2046">IANA media type</a> for the RDF syntax.
@@ -100,7 +101,19 @@ public enum RDFSyntax {
 	 * <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">HTTP protocol</a>. 
 	 */
 	public final String mediaType;
-		
+	
+	/**
+	 * The <a href="https://tools.ietf.org/html/rfc2046">IANA-registered</a> file extension.
+	 * <p>
+	 * The file extension includes the leading period, e.g. <code>.jsonld</code>
+	 */
+	public final String fileExtension;
+	
+	/**
+	 * Indicate if this RDF syntax supports <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Datasets</a>. 
+	 */
+	public final boolean supportsDataset;
+	
 	private final String name;
 	
 	/** 
@@ -113,9 +126,11 @@ public enum RDFSyntax {
 		return name;
 	}
 	
-	private RDFSyntax(String name, String mediaType) {
+	private RDFSyntax(String name, String mediaType, String fileExtension, boolean supportsDataset) {
 		this.name = name;
 		this.mediaType = mediaType;
+		this.fileExtension = fileExtension;
+		this.supportsDataset = supportsDataset;
 	}
 	
 	/**
@@ -143,6 +158,30 @@ public enum RDFSyntax {
 		
 		for (RDFSyntax syntax : RDFSyntax.values()) {
 			if (mediaType.equals(syntax.mediaType)) { 
+				return Optional.of(syntax);
+			}
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * Return the RDFSyntax with the specified file extension.
+	 * <p>
+	 * The <code>fileExtension</code> is compared in lower case, therefore it
+	 * might not be equal to the {@link RDFSyntax#fileExtension} of the returned
+	 * RDFSyntax.
+	 * 
+	 * @param fileExtension
+	 *            The fileExtension to match, starting with <code>.</code>
+	 * @return If {@link Optional#isPresent()}, the {@link RDFSyntax} which has
+	 *         a matching {@link RDFSyntax#fileExtension}, otherwise
+	 *         {@link Optional#empty()} indicating that no matching file
+	 *         extension was found.
+	 */
+	public static Optional<RDFSyntax> byFileExtension(String fileExtension) {
+		fileExtension = fileExtension.toLowerCase(Locale.ENGLISH);
+		for (RDFSyntax syntax : RDFSyntax.values()) {
+			if (fileExtension.equals(syntax.fileExtension)) {
 				return Optional.of(syntax);
 			}
 		}

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFSyntax.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFSyntax.java
@@ -17,6 +17,7 @@
  */
 package org.apache.commons.rdf.api;
 
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -153,15 +154,10 @@ public enum RDFSyntax {
 	 *         no matching syntax was found.
 	 */
 	public static Optional<RDFSyntax> byMediaType(String mediaType) {
-		mediaType = mediaType.toLowerCase(Locale.ENGLISH);
-		mediaType = mediaType.split("\\s*[;,]")[0];
-		
-		for (RDFSyntax syntax : RDFSyntax.values()) {
-			if (mediaType.equals(syntax.mediaType)) { 
-				return Optional.of(syntax);
-			}
-		}
-		return Optional.empty();
+		final String type = mediaType.toLowerCase(Locale.ENGLISH).
+				split("\\s*[;,]", 2)[0];
+		return Arrays.stream(RDFSyntax.values()).filter(
+				t -> t.mediaType.equals(type)).findAny();		
 	}
 
 	/**
@@ -178,14 +174,10 @@ public enum RDFSyntax {
 	 *         {@link Optional#empty()} indicating that no matching file
 	 *         extension was found.
 	 */
-	public static Optional<RDFSyntax> byFileExtension(String fileExtension) {
-		fileExtension = fileExtension.toLowerCase(Locale.ENGLISH);
-		for (RDFSyntax syntax : RDFSyntax.values()) {
-			if (fileExtension.equals(syntax.fileExtension)) {
-				return Optional.of(syntax);
-			}
-		}
-		return Optional.empty();
+	public static Optional<RDFSyntax> byFileExtension(String fileExtension) {		
+		final String ext = fileExtension.toLowerCase(Locale.ENGLISH);
+		return Arrays.stream(RDFSyntax.values()).filter(
+				t -> t.fileExtension.equals(ext)).findAny();		
 	}
 
 }

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFSyntax.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFSyntax.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.api;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/** 
+ * Enumeration of the RDF 1.1 serialization syntaxes.
+ * <p>
+ * This enumeration lists the W3C standardized 
+ * RDF 1.1 syntaxes like {@link #TURTLE} and {@link #JSONLD}.  
+ * Note the existence of other RDF syntaxes that are not included here, e.g. <a href="http://www.w3.org/TeamSubmission/n3/">N3</a> 
+ * and <a href="https://en.wikipedia.org/wiki/TriX_%28syntax%29">TriX</a>.
+ * 
+ * @see <a href="https://www.w3.org/TR/rdf11-primer/#section-graph-syntax">RDF 1.1 Primer</a>
+ *
+ */
+public enum RDFSyntax {
+	
+	/**
+	 * JSON-LD 1.0
+	 * 
+	 * @see <a href="https://www.w3.org/TR/json-ld/">https://www.w3.org/TR/json-ld/</a>
+	 * 
+	 */
+	JSONLD("JSON-LD 1.0", "application/ld+json"),
+
+	/**
+	 * RDF 1.1 Turtle
+	 * 
+	 * @see <a href="https://www.w3.org/TR/turtle/">RDF 1.1 Turtle</a>
+	 *
+	 */
+	TURTLE("RDF 1.1 Turtle", "text/turtle"), 
+
+	/**
+	 * RDF 1.1 N-Quads
+	 * 
+	 * @see <a href="https://www.w3.org/TR/n-quads/">https://www.w3.org/TR/n-quads/</a>
+	 */
+	NQUADS("RDF 1.1 N-Quads", "application/n-quads"),
+
+	/**
+	 * RDF 1.1 N-Triples
+	 * 
+	 * @see <a href="https://www.w3.org/TR/n-triples/">https://www.w3.org/TR/n-triples/</a>
+	 */
+	NTRIPLES("RDF 1.1 N-Triples", "application/n-triples"),
+	
+	/**
+	 * HTML+RDFa 1.1
+	 * 
+	 * @see <a href="https://www.w3.org/TR/html-rdfa/">https://www.w3.org/TR/html-rdfa/</a>
+	 */
+	RDFA_HTML("HTML+RDFa 1.1", "text/html"),
+	
+	/**
+	 * XHTML+RDFa 1.1 
+	 * 
+	 * @see <a href="https://www.w3.org/TR/xhtml-rdfa/">https://www.w3.org/TR/xhtml-rdfa/</a> 
+	 */
+	RDFA_XHTML("XHTML+RDFa 1.1", "application/xhtml+xml"),
+	
+	/**
+	 * RDF 1.1 XML Syntax
+	 * 
+	 * @see <a href="https://www.w3.org/TR/rdf-syntax-grammar/">https://www.w3.org/TR/rdf-syntax-grammar/</a>
+	 */
+	RDFXML("RDF 1.1 XML Syntax", "application/rdf+xml"),
+	
+	/**
+	 * RDF 1.1 TriG
+	 * 
+	 * @see <a href="https://www.w3.org/TR/trig/">https://www.w3.org/TR/trig/</a>
+	 */
+	TRIG("RDF 1.1 TriG", "application/trig");
+
+	/** 
+	 * The <a href="https://tools.ietf.org/html/rfc2046">IANA media type</a> for the RDF syntax.
+	 * <p> 
+	 * The media type can be used as part of 
+	 * <code>Content-Type</code> 
+	 * and <code>Accept</code> for <em>content negotiation</em> in the 
+	 * <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">HTTP protocol</a>. 
+	 */
+	public final String mediaType;
+		
+	private final String name;
+	
+	/** 
+	 * A human-readable name for the RDF syntax.
+	 * <p>
+	 * The name is equivalent to the the title of the corresponding W3C Specification.
+	 */
+	@Override
+	public String toString() {
+		return name;
+	}
+	
+	private RDFSyntax(String name, String mediaType) {
+		this.name = name;
+		this.mediaType = mediaType;
+	}
+	
+	/**
+	 * Return the RDFSyntax with the specified media type.
+	 * <p>
+	 * The <code>mediaType</code> is compared in lower case, therefore it might
+	 * not be equal to the {@link RDFSyntax#mediaType} of the returned
+	 * RDFSyntax.
+	 * <p>
+	 * For convenience matching of media types used in a
+	 * <code>Content-Type</code> header, if the <code>mediaType</code> contains
+	 * the characters <code>;</code>, <code>,</code> or white space, only the
+	 * part of the string to the left of those characters are considered.
+	 * 
+	 * @param mediaType
+	 *            The media type to match
+	 * @return If {@link Optional#isPresent()}, the {@link RDFSyntax} which has
+	 *         a matching {@link RDFSyntax#mediaType}, otherwise
+	 *         {@link Optional#empty()} indicating that 
+	 *         no matching syntax was found.
+	 */
+	public static Optional<RDFSyntax> byMediaType(String mediaType) {
+		mediaType = mediaType.toLowerCase(Locale.ENGLISH);
+		mediaType = mediaType.split("\\s*[;,]")[0];
+		
+		for (RDFSyntax syntax : RDFSyntax.values()) {
+			if (mediaType.equals(syntax.mediaType)) { 
+				return Optional.of(syntax);
+			}
+		}
+		return Optional.empty();
+	}
+
+}

--- a/api/src/main/java/org/apache/commons/rdf/api/package-info.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/package-info.java
@@ -38,6 +38,9 @@
  * MAY be mutable (e.g. support methods like
  * {@link org.apache.commons.rdf.api.Graph#add(Triple)}).
  * <p>
+ * {@link org.apache.commons.rdf.api.RDFSyntax} enumerates the 
+ * W3C standard RDF 1.1 syntaxes and their media types.
+ * <p>
  * For further documentation and contact details, see the
  * <a href="http://commonsrdf.incubator.apache.org/">Commons RDF</a>
  * web site.

--- a/api/src/test/java/org/apache/commons/rdf/api/RDFSyntaxTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/RDFSyntaxTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.api;
+
+import static org.junit.Assert.*;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+public class RDFSyntaxTest {
+
+	@Test
+	public void mediaType() throws Exception {
+		assertEquals("application/ld+json", RDFSyntax.JSONLD.mediaType);
+		assertEquals("application/n-quads", RDFSyntax.NQUADS.mediaType);
+		assertEquals("application/n-triples", RDFSyntax.NTRIPLES.mediaType);
+		assertEquals("text/html", RDFSyntax.RDFA_HTML.mediaType);
+		assertEquals("application/xhtml+xml", RDFSyntax.RDFA_XHTML.mediaType);
+		assertEquals("application/rdf+xml", RDFSyntax.RDFXML.mediaType);
+		assertEquals("application/trig", RDFSyntax.TRIG.mediaType);
+		assertEquals("text/turtle", RDFSyntax.TURTLE.mediaType);
+	}
+
+	@Test
+	public void byMediaType() throws Exception {
+		assertEquals(RDFSyntax.JSONLD, RDFSyntax.byMediaType("application/ld+json").get());
+		assertEquals(RDFSyntax.NQUADS, RDFSyntax.byMediaType("application/n-quads").get());
+		assertEquals(RDFSyntax.NTRIPLES, RDFSyntax.byMediaType("application/n-triples").get());
+		assertEquals(RDFSyntax.RDFA_HTML, RDFSyntax.byMediaType("text/html").get());
+		assertEquals(RDFSyntax.RDFA_XHTML, RDFSyntax.byMediaType("application/xhtml+xml").get());
+		assertEquals(RDFSyntax.RDFXML, RDFSyntax.byMediaType("application/rdf+xml").get());
+		assertEquals(RDFSyntax.TRIG, RDFSyntax.byMediaType("application/trig").get());
+		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byMediaType("text/turtle").get());
+	}
+
+	@Test
+	public void name() throws Exception {
+		assertEquals("JSON-LD 1.0", RDFSyntax.JSONLD.toString());
+		assertEquals("RDF 1.1 Turtle", RDFSyntax.TURTLE.toString());
+	}
+
+	@Test
+	public void byMediaTypeUnknown() throws Exception {
+		assertEquals(Optional.empty(), RDFSyntax.byMediaType("application/octet-stream"));
+	}
+
+	@Test
+	public void byMediaTypeLowerCase() throws Exception {
+		assertEquals(RDFSyntax.JSONLD, RDFSyntax.byMediaType("APPLICATION/ld+JSON").get());
+	}
+
+	@Test
+	public void byMediaTypeContentType() throws Exception {
+		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byMediaType("text/turtle; charset=\"UTF-8\"").get());
+		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byMediaType("text/turtle ; charset=\"UTF-8\"").get());
+		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byMediaType("text/turtle, text/plain").get());
+		assertEquals(Optional.empty(), RDFSyntax.byMediaType(" text/turtle"));
+	}
+
+}

--- a/api/src/test/java/org/apache/commons/rdf/api/RDFSyntaxTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/RDFSyntaxTest.java
@@ -26,15 +26,30 @@ import org.junit.Test;
 public class RDFSyntaxTest {
 
 	@Test
-	public void mediaType() throws Exception {
-		assertEquals("application/ld+json", RDFSyntax.JSONLD.mediaType);
-		assertEquals("application/n-quads", RDFSyntax.NQUADS.mediaType);
-		assertEquals("application/n-triples", RDFSyntax.NTRIPLES.mediaType);
-		assertEquals("text/html", RDFSyntax.RDFA_HTML.mediaType);
-		assertEquals("application/xhtml+xml", RDFSyntax.RDFA_XHTML.mediaType);
-		assertEquals("application/rdf+xml", RDFSyntax.RDFXML.mediaType);
-		assertEquals("application/trig", RDFSyntax.TRIG.mediaType);
-		assertEquals("text/turtle", RDFSyntax.TURTLE.mediaType);
+	public void byFileExtension() throws Exception {
+		assertEquals(RDFSyntax.JSONLD, RDFSyntax.byFileExtension(".jsonld").get());
+		assertEquals(RDFSyntax.NQUADS, RDFSyntax.byFileExtension(".nq").get());
+		assertEquals(RDFSyntax.NTRIPLES, RDFSyntax.byFileExtension(".nt").get());
+		assertEquals(RDFSyntax.RDFA_HTML, RDFSyntax.byFileExtension(".html").get());
+		assertEquals(RDFSyntax.RDFA_XHTML, RDFSyntax.byFileExtension(".xhtml").get());
+		assertEquals(RDFSyntax.RDFXML, RDFSyntax.byFileExtension(".rdf").get());
+		assertEquals(RDFSyntax.TRIG, RDFSyntax.byFileExtension(".trig").get());
+		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byFileExtension(".ttl").get());
+	}
+
+	@Test
+	public void byFileExtensionFailsWithoutDot() throws Exception {
+		assertEquals(Optional.empty(), RDFSyntax.byFileExtension("rdf"));
+	}
+
+	@Test
+	public void byFileExtensionLowerCase() throws Exception {
+		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byFileExtension(".TtL").get());
+	}
+
+	@Test
+	public void byFileExtensionUnknown() throws Exception {
+		assertEquals(Optional.empty(), RDFSyntax.byFileExtension(".tar"));
 	}
 
 	@Test
@@ -50,14 +65,11 @@ public class RDFSyntaxTest {
 	}
 
 	@Test
-	public void name() throws Exception {
-		assertEquals("JSON-LD 1.0", RDFSyntax.JSONLD.toString());
-		assertEquals("RDF 1.1 Turtle", RDFSyntax.TURTLE.toString());
-	}
-
-	@Test
-	public void byMediaTypeUnknown() throws Exception {
-		assertEquals(Optional.empty(), RDFSyntax.byMediaType("application/octet-stream"));
+	public void byMediaTypeContentType() throws Exception {
+		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byMediaType("text/turtle; charset=\"UTF-8\"").get());
+		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byMediaType("text/turtle ; charset=\"UTF-8\"").get());
+		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byMediaType("text/turtle, text/plain").get());
+		assertEquals(Optional.empty(), RDFSyntax.byMediaType(" text/turtle"));
 	}
 
 	@Test
@@ -66,11 +78,38 @@ public class RDFSyntaxTest {
 	}
 
 	@Test
-	public void byMediaTypeContentType() throws Exception {
-		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byMediaType("text/turtle; charset=\"UTF-8\"").get());
-		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byMediaType("text/turtle ; charset=\"UTF-8\"").get());
-		assertEquals(RDFSyntax.TURTLE, RDFSyntax.byMediaType("text/turtle, text/plain").get());
-		assertEquals(Optional.empty(), RDFSyntax.byMediaType(" text/turtle"));
+	public void byMediaTypeUnknown() throws Exception {
+		assertEquals(Optional.empty(), RDFSyntax.byMediaType("application/octet-stream"));
+	}
+
+	@Test
+	public void fileExtension() throws Exception {
+		assertEquals(".jsonld", RDFSyntax.JSONLD.fileExtension);
+		assertEquals(".nq", RDFSyntax.NQUADS.fileExtension);
+		assertEquals(".nt", RDFSyntax.NTRIPLES.fileExtension);
+		assertEquals(".html", RDFSyntax.RDFA_HTML.fileExtension);
+		assertEquals(".xhtml", RDFSyntax.RDFA_XHTML.fileExtension);
+		assertEquals(".rdf", RDFSyntax.RDFXML.fileExtension);
+		assertEquals(".trig", RDFSyntax.TRIG.fileExtension);
+		assertEquals(".ttl", RDFSyntax.TURTLE.fileExtension);
+	}
+
+	@Test
+	public void mediaType() throws Exception {
+		assertEquals("application/ld+json", RDFSyntax.JSONLD.mediaType);
+		assertEquals("application/n-quads", RDFSyntax.NQUADS.mediaType);
+		assertEquals("application/n-triples", RDFSyntax.NTRIPLES.mediaType);
+		assertEquals("text/html", RDFSyntax.RDFA_HTML.mediaType);
+		assertEquals("application/xhtml+xml", RDFSyntax.RDFA_XHTML.mediaType);
+		assertEquals("application/rdf+xml", RDFSyntax.RDFXML.mediaType);
+		assertEquals("application/trig", RDFSyntax.TRIG.mediaType);
+		assertEquals("text/turtle", RDFSyntax.TURTLE.mediaType);
+	}
+
+	@Test
+	public void name() throws Exception {
+		assertEquals("JSON-LD 1.0", RDFSyntax.JSONLD.toString());
+		assertEquals("RDF 1.1 Turtle", RDFSyntax.TURTLE.toString());
 	}
 
 }


### PR DESCRIPTION
e.g. Turtle, JSON-LD

This enumeration deliberately only lists RDF 1.1 standardized syntaxes (e.g. does not include N3).

The only field (beyond the name for toString()), the official `mediaType`, which can be used with `byMediaType(String)` for a look up from e.g. `Content-Type` headers.

These constants (at least their content type) should be useful for anyone doing RDF parsing or writing.

See also the [JavaDoc for RDFSyntax](https://cdn.rawgit.com/stain/e4447eb261e64fdc9028/raw/8d2d22ee38376b0b8214e5eae7ea3ae325964ac4/RDFSyntax.html).
