### PR TITLE
Add Quad and Dataset

### DIFF
--- a/RELEASE-PROCESS.md
+++ b/RELEASE-PROCESS.md
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
 # Commons RDF (incubating) release process
 
 1. Update documentation (`RELEASE-NOTES.md`, `README.md`, version numbers in `src/site/`)

--- a/api/src/main/java/org/apache/commons/rdf/api/Dataset.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Dataset.java
@@ -1,0 +1,338 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.api;
+
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * An <a href="http://www.w3.org/TR/rdf11-concepts/#section-rdf-dataset"> RDF
+ * 1.1 dataset</a>, a set of RDF quads, as defined by
+ * <a href="http://www.w3.org/TR/rdf11-concepts/" >RDF-1.1 Concepts and Abstract
+ * Syntax</a>, a W3C Recommendation published on 25 February 2014.
+ */
+public interface Dataset extends AutoCloseable, GraphLike<Quad, BlankNodeOrIRI, IRI, RDFTerm> {
+
+	/**
+	 * Add a quad to the dataset, possibly mapping any of the components of the
+	 * Quad to those supported by this dataset.
+	 *
+	 * @param quad
+	 *            The quad to add
+	 */
+	void add(Quad quad);
+
+	/**
+	 * Add a quad to the dataset, possibly mapping any of the components to
+	 * those supported by this dataset.
+	 *
+	 * @param graphName
+	 *            The graph the quad belongs to, or <code>null</code> for the
+	 *            default graph
+	 * @param subject
+	 *            The quad subject
+	 * @param predicate
+	 *            The quad predicate
+	 * @param object
+	 *            The quad object
+	 */
+	void add(BlankNodeOrIRI graphName, BlankNodeOrIRI subject, IRI predicate, RDFTerm object);
+
+	/**
+	 * Check if dataset contains quad.
+	 *
+	 * @param quad
+	 *            The quad to check.
+	 * @return True if the dataset contains the given Quad.
+	 */
+	boolean contains(Quad quad);
+
+	/**
+	 * Check if dataset contains a pattern of quads.
+	 *
+	 * @param graphName
+	 *            The graph the quad belongs to, wrapped as an {@link Optional}
+	 *            (<code>null</code> is a wildcard, {@link Optional#empty()} is
+	 *            the default graph)
+	 * @param subject
+	 *            The quad subject (<code>null</code> is a wildcard)
+	 * @param predicate
+	 *            The quad predicate (<code>null</code> is a wildcard)
+	 * @param object
+	 *            The quad object (<code>null</code> is a wildcard)
+	 * @return True if the dataset contains any quads that match the given
+	 *         pattern.
+	 */
+	boolean contains(Optional<BlankNodeOrIRI> graphName, BlankNodeOrIRI subject, IRI predicate, RDFTerm object);
+
+	/**
+	 * Close the dataset, relinquishing any underlying resources.
+	 * <p>
+	 * For example, this would close any open file and network streams and free
+	 * database locks held by the dataset implementation.
+	 * <p>
+	 * The behaviour of the other dataset methods are undefined after closing
+	 * the dataset.
+	 * <p>
+	 * Implementations might not need {@link #close()}, hence the default
+	 * implementation does nothing.
+	 */
+	@Override
+	default void close() throws Exception {
+	}
+
+	/**
+	 * Get the default graph of this dataset.
+	 * <p>
+	 * The {@link Triple}s of the default graph are equivalent to the
+	 * {@link Quad}s in this Dataset which has the {@link Quad#getGraphName()}
+	 * set to {@link Optional#empty()}.
+	 * <p>
+	 * It is unspecified if modifications to the returned Graph are reflected in
+	 * this Dataset.
+	 * <p>
+	 * The returned graph MAY be empty.
+	 * 
+	 * @see #getGraph(BlankNodeOrIRI)
+	 * @return The default graph of this Dataset
+	 */
+	Graph getGraph();
+	
+	/**
+	 * Get a named graph in this dataset.
+	 * <p>
+	 * The {@link Triple}s of the named graph are equivalent to the
+	 * the Quads of this Dataset which has the
+	 * {@link Quad#getGraphName()} equal to the provided <code>graphName</code>, or
+	 * equal to {@link Optional#empty()} if the provided <code>graphName</code> is
+	 * <code>null</code>.
+	 * <p>
+	 * It is unspecified if modifications to the returned Graph are reflected in
+	 * this Dataset.
+	 * <p>
+	 * It is unspecified if requesting an unknown or empty graph will return
+	 * {@link Optional#empty()} or create a new empty {@link Graph}.
+	 * 
+	 * @see #getGraph()
+	 * @see #getGraphNames()
+	 * @param graphName
+	 *            The name of the graph, or <code>null</code> for the default
+	 *            graph.
+	 * @return The named Graph, or {@link Optional#empty()} if the dataset do
+	 *         not contain the named graph.
+	 */	
+	Optional<Graph> getGraph(BlankNodeOrIRI graphName);	
+	
+	/**
+	 * Get the graph names in this Dataset.
+	 * <p>
+	 * The set of returned graph names is equivalent to the set of unique
+	 * {@link Quad#getGraphName()} of all the {@link #stream()} of this
+	 * dataset (excluding the default graph).
+	 * <p>
+	 * The returned {@link Stream} SHOULD NOT contain duplicate graph names.
+	 * <p>
+	 * The graph names can be used with {@link #getGraph(BlankNodeOrIRI)} to
+	 * retrieve the corresponding {@link Graph}, however callers should be aware
+	 * of any concurrent modifications to the Dataset may cause such calls to
+	 * return {@link Optional#empty()}.
+	 * <p>
+	 * Note that a Dataset always contains a <strong>default graph</strong>
+	 * which is not named, and thus is not represented in the returned Stream.
+	 * The default graph is accessible via {@link #getGraph()} or by using
+	 * {@link Optional#empty()} in the Quad access methods).
+	 * 
+	 * @return A {@link Stream} of the graph names of this Dataset.
+	 */
+	Stream<BlankNodeOrIRI> getGraphNames();
+	
+	/**
+	 * Remove a concrete quad from the dataset.
+	 *
+	 * @param quad
+	 *            quad to remove
+	 */
+	void remove(Quad quad);
+
+	/**
+	 * Remove a concrete pattern of quads from the default graph of the dataset.
+	 *
+	 * @param graphName
+	 *            The graph the quad belongs to, wrapped as an {@link Optional}
+	 *            (<code>null</code> is a wildcard, {@link Optional#empty()} is
+	 *            the default graph)
+	 * @param subject
+	 *            The quad subject (<code>null</code> is a wildcard)
+	 * @param predicate
+	 *            The quad predicate (<code>null</code> is a wildcard)
+	 * @param object
+	 *            The quad object (<code>null</code> is a wildcard)
+	 */
+	void remove(Optional<BlankNodeOrIRI> graphName, BlankNodeOrIRI subject, IRI predicate, RDFTerm object);
+
+	/**
+	 * Clear the dataset, removing all quads.
+	 */
+	void clear();
+
+	/**
+	 * Number of quads contained by the dataset.
+	 * <p>
+	 * The count of a set does not include duplicates, consistent with the
+	 * {@link Quad#equals(Object)} equals method for each {@link Quad}.
+	 *
+	 * @return The number of quads in the dataset
+	 */
+	long size();
+
+	/**
+	 * Get all quads contained by the dataset.<br>
+	 * <p>
+	 * The iteration does not contain any duplicate quads, as determined by the
+	 * {@link Quad#equals(Object)} method for each {@link Quad}.
+	 * <p>
+	 * The behaviour of the {@link Stream} is not specified if
+	 * {@link #add(Quad)}, {@link #remove(Quad)} or {@link #clear()} are called
+	 * on the {@link Dataset} before it terminates.
+	 * <p>
+	 * Implementations may throw {@link ConcurrentModificationException} from
+	 * Stream methods if they detect a conflict while the Stream is active.
+	 *
+	 * @return A {@link Stream} over all of the quads in the dataset
+	 */
+	Stream<? extends Quad> stream();
+
+	/**
+	 * Get all quads contained by the dataset matched with the pattern.
+	 * <p>
+	 * The iteration does not contain any duplicate quads, as determined by the
+	 * {@link Quad#equals(Object)} method for each {@link Quad}.
+	 * <p>
+	 * The behaviour of the {@link Stream} is not specified if
+	 * {@link #add(Quad)}, {@link #remove(Quad)} or {@link #clear()} are called
+	 * on the {@link Dataset} before it terminates.
+	 * <p>
+	 * Implementations may throw {@link ConcurrentModificationException} from
+	 * Stream methods if they detect a conflict while the Stream is active.
+	 *
+	 * @param graphName
+	 *            The graph the quad belongs to, wrapped as an {@link Optional}
+	 *            (<code>null</code> is a wildcard, {@link Optional#empty()} is
+	 *            the default graph)
+	 * @param subject
+	 *            The quad subject (<code>null</code> is a wildcard)
+	 * @param predicate
+	 *            The quad predicate (<code>null</code> is a wildcard)
+	 * @param object
+	 *            The quad object (<code>null</code> is a wildcard)
+	 * @return A {@link Stream} over the matched quads.
+	 */
+	Stream<? extends Quad> stream(Optional<BlankNodeOrIRI> graphName, BlankNodeOrIRI subject, IRI predicate,
+			RDFTerm object);
+
+	/**
+	 * Get an Iterable for iterating over all quads in the dataset.
+	 * <p>
+	 * This method is meant to be used with a Java for-each loop, e.g.:
+	 * 
+	 * <pre>
+	 * for (Quad t : dataset.iterate()) {
+	 * 	System.out.println(t);
+	 * }
+	 * </pre>
+	 * 
+	 * The behaviour of the iterator is not specified if {@link #add(Quad)},
+	 * {@link #remove(Quad)} or {@link #clear()}, are called on the
+	 * {@link Dataset} before it terminates. It is undefined if the returned
+	 * {@link Iterator} supports the {@link Iterator#remove()} method.
+	 * <p>
+	 * Implementations may throw {@link ConcurrentModificationException} from
+	 * Iterator methods if they detect a concurrency conflict while the Iterator
+	 * is active.
+	 * <p>
+	 * The {@link Iterable#iterator()} must only be called once, that is the
+	 * Iterable must only be iterated over once. A {@link IllegalStateException}
+	 * may be thrown on attempt to reuse the Iterable.
+	 *
+	 * @return A {@link Iterable} that returns {@link Iterator} over all of the
+	 *         quads in the dataset
+	 * @throws IllegalStateException
+	 *             if the {@link Iterable} has been reused
+	 * @throws ConcurrentModificationException
+	 *             if a concurrency conflict occurs while the Iterator is
+	 *             active.
+	 */
+	@SuppressWarnings("unchecked")
+	default Iterable<Quad> iterate() throws ConcurrentModificationException, IllegalStateException {
+		return ((Stream<Quad>) stream())::iterator;
+	}
+
+	/**
+	 * Get an Iterable for iterating over the quads in the dataset that match
+	 * the pattern.
+	 * <p>
+	 * This method is meant to be used with a Java for-each loop, e.g.:
+	 * 
+	 * <pre>
+	 * IRI alice = factory.createIRI("http://example.com/alice");
+	 * IRI knows = factory.createIRI("http://xmlns.com/foaf/0.1/");
+	 * for (Quad t : dataset.iterate(null, alice, knows, null)) {
+	 * 	   System.out.println(t.getGraphName()); 
+	 *     System.out.println(t.getObject());
+	 * }
+	 * </pre>
+	 * <p>
+	 * The behaviour of the iterator is not specified if {@link #add(Quad)},
+	 * {@link #remove(Quad)} or {@link #clear()}, are called on the
+	 * {@link Dataset} before it terminates. It is undefined if the returned
+	 * {@link Iterator} supports the {@link Iterator#remove()} method.
+	 * <p>
+	 * Implementations may throw {@link ConcurrentModificationException} from
+	 * Iterator methods if they detect a concurrency conflict while the Iterator
+	 * is active.
+	 * <p>
+	 * The {@link Iterable#iterator()} must only be called once, that is the
+	 * Iterable must only be iterated over once. A {@link IllegalStateException}
+	 * may be thrown on attempt to reuse the Iterable.
+	 *
+	 * @param graphName
+	 *            The graph the quad belongs to, wrapped as an {@link Optional}
+	 *            (<code>null</code> is a wildcard, {@link Optional#empty()} is
+	 *            the default graph)
+	 * @param subject
+	 *            The quad subject (<code>null</code> is a wildcard)
+	 * @param predicate
+	 *            The quad predicate (<code>null</code> is a wildcard)
+	 * @param object
+	 *            The quad object (<code>null</code> is a wildcard)
+	 * @return A {@link Iterable} that returns {@link Iterator} over the
+	 *         matching quads in the dataset
+	 * @throws IllegalStateException
+	 *             if the {@link Iterable} has been reused
+	 * @throws ConcurrentModificationException
+	 *             if a concurrency conflict occurs while the Iterator is
+	 *             active.
+	 */
+	@SuppressWarnings("unchecked")
+	default Iterable<Quad> iterate(Optional<BlankNodeOrIRI> graphName, BlankNodeOrIRI subject, IRI predicate,
+			RDFTerm object) throws ConcurrentModificationException, IllegalStateException {
+		return ((Stream<Quad>) stream(graphName, subject, predicate, object))::iterator;
+	}
+}

--- a/api/src/main/java/org/apache/commons/rdf/api/Graph.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Graph.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
  * href="http://www.w3.org/TR/rdf11-concepts/" >RDF-1.1 Concepts and Abstract
  * Syntax</a>, a W3C Recommendation published on 25 February 2014.
  */
-public interface Graph extends AutoCloseable {
+public interface Graph extends AutoCloseable,GraphLike<Triple, BlankNodeOrIRI, IRI, RDFTerm> {
 
     /**
      * Add a triple to the graph, possibly mapping any of the components of the
@@ -125,11 +125,12 @@ public interface Graph extends AutoCloseable {
      * <p>
      * Implementations may throw {@link ConcurrentModificationException} from Stream
      * methods if they detect a conflict while the Stream is active.
-     *
+     * 
+     * @since 0.3.0-incubating
      * @return A {@link Stream} over all of the triples in the graph
      */
-    Stream<? extends Triple> getTriples();
-
+    Stream<? extends Triple> stream();
+    
     /**
      * Get all triples contained by the graph matched with the pattern.
      * <p>
@@ -142,15 +143,38 @@ public interface Graph extends AutoCloseable {
      * <p>
      * Implementations may throw {@link ConcurrentModificationException} from Stream
      * methods if they detect a conflict while the Stream is active.
-     *
+     * <p>
+     * 
+     * @since 0.3.0-incubating
      * @param subject   The triple subject (null is a wildcard)
      * @param predicate The triple predicate (null is a wildcard)
      * @param object    The triple object (null is a wildcard)
      * @return A {@link Stream} over the matched triples.
      */
-    Stream<? extends Triple> getTriples(BlankNodeOrIRI subject, IRI predicate,
+    Stream<? extends Triple> stream(BlankNodeOrIRI subject, IRI predicate,
                                         RDFTerm object);
 
+    /**
+     * This method is deprecated, use the equivalent method 
+     * {@link #stream()} instead. 
+     * 
+     */
+    @Deprecated
+    default Stream<? extends Triple> getTriples() {
+    	return stream();
+    }
+
+    /**
+     * This method is deprecated, use the equivalent method 
+     * {@link #stream(BlankNodeOrIRI, IRI, RDFTerm)} instead.
+     * 
+     */
+    @Deprecated    
+    default Stream<? extends Triple> getTriples(BlankNodeOrIRI subject, IRI predicate,
+            RDFTerm object) {
+    	return stream(subject, predicate, object);
+    }
+    
     /**
      * Get an Iterable for iterating over all triples in the graph.
      * <p>
@@ -184,7 +208,7 @@ public interface Graph extends AutoCloseable {
     @SuppressWarnings("unchecked")
     default Iterable<Triple> iterate()
             throws ConcurrentModificationException, IllegalStateException {
-        return ((Stream<Triple>)getTriples())::iterator;
+        return ((Stream<Triple>)stream())::iterator;
     }
 
     /**
@@ -231,6 +255,6 @@ public interface Graph extends AutoCloseable {
     default Iterable<Triple> iterate(
             BlankNodeOrIRI subject, IRI predicate, RDFTerm object)
         throws ConcurrentModificationException, IllegalStateException {
-        return ((Stream<Triple>) getTriples(subject, predicate, object))::iterator;
+        return ((Stream<Triple>) stream(subject, predicate, object))::iterator;
     }
 }

--- a/api/src/main/java/org/apache/commons/rdf/api/GraphLike.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/GraphLike.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.api;
+
+import java.util.ConcurrentModificationException;
+import java.util.stream.Stream;
+
+/**
+ * A "graph-like" interface that contains {@link TripleLike} statements.
+ * <p>
+ * Extended by {@link Graph} (for {@link Triple}) and {@link Dataset} (for
+ * {@link Quad}).
+ * <p>
+ * Unlike {@link Graph} and {@link Dataset}, this interface can support with
+ * generalised {@link TripleLike} or {@link QuadLike} statements, and does not
+ * include semantics like {@link #size()} or the requirement of mapping
+ * {@link RDFTerm} instances from different implementations.
+ * <p>
+ * As {@link TripleLike} do not have a specific {@link Object#equals(Object)}
+ * semantics, the behaviour of methods like {@link #contains(TripleLike)} and
+ * {@link #remove(TripleLike)} is undefined for arguments that are not object
+ * identical to previously added or returned {@link TripleLike} statements.
+ * 
+ * @param <T>
+ *            A {@link TripleLike} type used by the graph methods, typically
+ *            {@link Triple} or {@link Quad}
+ * @param <S>
+ *            The type of subjects in the statements, typically
+ *            {@link BlankNodeOrIRI}
+ * @param <P>
+ *            The type of predicates in the statements, typically {@link IRI}
+ * @param <O>
+ *            The type of objects in the statements, typically {@link RDFTerm}
+ *            
+ * @since 0.3.0-incubating
+ * @see Graph
+ * @see Dataset
+ * @see TripleLike
+ */
+public interface GraphLike<T extends TripleLike<S, P, O>, S extends RDFTerm, P extends RDFTerm, O extends RDFTerm> {
+
+	/**
+	 * Add a statement.
+	 * 
+	 * @param statement
+	 *            The TripleLike statement to add
+	 */
+	void add(T statement);
+
+	/**
+	 * Check if statement is contained.
+	 * 
+	 * @param statement
+	 *            The {@link TripleLike} statement to check
+	 * @return True if the statement is contained
+	 */
+	boolean contains(T statement);
+
+	/**
+	 * Add a statement.
+	 * 
+	 * @param statement
+	 *            The TripleLike statement to add
+	 */
+	void remove(T statement);
+
+	/**
+	 * Remove all statements.
+	 */
+	void clear();
+
+	/**
+	 * Number of statements.
+	 * 
+	 * @return Number of statements
+	 */
+	long size();
+
+	/**
+	 * Return a Stream of contained statements.
+	 * 
+	 * @return A {@link Stream} of {@link TripleLike} statements.
+	 */
+	Stream<? extends T> stream();
+
+	/**
+	 * Iterate over contained statements.
+	 * 
+	 * @return An {@link Iterable} of {@link TripleLike} statements.
+	 * @throws IllegalStateException
+	 *             if the {@link Iterable} has been reused
+	 * @throws ConcurrentModificationException
+	 *             if a concurrency conflict occurs while the Iterator is
+	 *             active.
+	 */
+	Iterable<T> iterate() throws ConcurrentModificationException, IllegalStateException;
+
+}

--- a/api/src/main/java/org/apache/commons/rdf/api/Quad.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Quad.java
@@ -1,0 +1,211 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.api;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A Quad is a statement in a
+ * <a href= "http://www.w3.org/TR/rdf11-concepts/#section-dataset" >RDF-1.1
+ * Dataset</a>, as defined by
+ * <a href= "https://www.w3.org/TR/2014/NOTE-rdf11-datasets-20140225/" >RDF-1.1
+ * Concepts and Abstract Syntax</a>, a W3C Working Group Note published on 25
+ * February 2014.
+ * 
+ * @since 0.3.0-incubating
+ * @see <a href="http://www.w3.org/TR/2014/NOTE-rdf11-datasets-20140225/">RDF
+ *      1.1: On Semantics of RDF Datasets</a>
+ * @see <a href="http://www.w3.org/TR/rdf11-concepts/#section-dataset"> </a>
+ */
+public interface Quad extends QuadLike<BlankNodeOrIRI,IRI,RDFTerm,BlankNodeOrIRI> {
+
+	/**
+	 * The graph name (graph label) of this quad, if present.
+	 * 
+	 * If {@link Optional#isPresent()}, then the {@link Optional#get()} is
+	 * either a {@link BlankNode} or an {@link IRI}, indicating the
+	 * <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-named-graph">graph
+	 * name of this Quad. If the graph name is not present, e.g. the value is
+	 * {@link Optional#empty()}, it indicates that this Quad is in the
+	 * <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-default-graph">default
+	 * graph.
+	 *
+	 * @return If {@link Optional#isPresent()}, the graph name
+	 *         {@link BlankNodeOrIRI} of this quad, otherwise
+	 *         {@link Optional#empty()}, indicating the default graph.
+	 * 
+	 * @see <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset">RDF-
+	 *      1.1 Dataset</a>
+	 */
+	Optional<BlankNodeOrIRI> getGraphName();
+
+	/**
+	 * The subject of this quad, which may be either a {@link BlankNode} or an
+	 * {@link IRI}, which are represented in Commons RDF by the interface
+	 * {@link BlankNodeOrIRI}.
+	 *
+	 * @return The subject {@link BlankNodeOrIRI} of this quad.
+	 * @see <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-subject">RDF-1.1
+	 *      Triple subject</a>
+	 */
+	BlankNodeOrIRI getSubject();
+
+	/**
+	 * The predicate {@link IRI} of this quad.
+	 *
+	 * @return The predicate {@link IRI} of this quad.
+	 * @see <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-predicate">RDF-1.1
+	 *      Triple predicate</a>
+	 */
+	IRI getPredicate();
+
+	/**
+	 * The object of this quad, which may be either a {@link BlankNode}, an
+	 * {@link IRI}, or a {@link Literal}, which are represented in Commons RDF
+	 * by the interface {@link RDFTerm}.
+	 *
+	 * @return The object {@link RDFTerm} of this quad.
+	 * @see <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-object">RDF-1.1
+	 *      Triple object</a>
+	 */
+	RDFTerm getObject();
+
+	/**
+	 * Adapt this Quad to a Triple.
+	 * <p>
+	 * The returned {@link Triple} will have equivalent values returned from the
+	 * methods {@link TripleLike#getSubject()},
+	 * {@link TripleLike#getPredicate()} and {@link TripleLike#getObject()}.
+	 * <p>
+	 * The returned {@link Triple} MUST NOT be {@link #equals(Object)} to this
+	 * {@link Quad}, even if this quad has a default graph
+	 * {@link #getGraphName()} value of {@link Optional#empty()}, but MUST
+	 * follow the {@link Triple#equals(Object)} semantics. This means that the
+	 * following MUST be true:
+     * 
+	 * <pre>
+	 * Quad q1, q2;
+	 * if (q1.equals(q2)) {
+	 * 	 assert(q1.asTriple().equals(q2.asTriple()));
+	 * } else if (q1.asTriple().equals(q2.asTriple())) {
+	 * 	 assert(q1.getSubject().equals(q2.getSubject()));
+	 * 	 assert(q1.getPredicate().equals(q2.getPredicate()));
+	 * 	 assert(q1.getObject().equals(q2.getObject()));
+	 * 	 assert(! q1.getGraphName().equals(q2.getGraphName()));
+	 * }
+	 * </pre>
+	 * 
+	 * The <code>default</code> implementation of this method return a proxy
+	 * {@link Triple} instance that keeps a reference to this {@link Quad} to
+	 * call the underlying {@link TripleLike} methods, but supplies a
+	 * {@link Triple} compatible implementation of {@link Triple#equals(Object)}
+	 * and {@link Triple#hashCode()}. Implementations may override this method,
+	 * e.g. for a more efficient solution.
+	 * 
+	 * @return A {@link Triple} that contains the same {@link TripleLike}
+	 *         properties as this Quad.
+	 */
+	default Triple asTriple() {
+		return new Triple() {
+			@Override
+			public BlankNodeOrIRI getSubject() {
+				return Quad.this.getSubject();
+			}
+
+			@Override
+			public IRI getPredicate() {
+				return Quad.this.getPredicate();
+			}
+
+			@Override
+			public RDFTerm getObject() {
+				return Quad.this.getObject();
+			}
+
+			@Override
+			public boolean equals(Object obj) {
+				if (obj == this)  { 
+					return true;
+				}
+				if (!(obj instanceof Triple)) {
+					return false;
+				}
+				Triple other = (Triple) obj;
+				return Objects.equals(getSubject(), other.getSubject())
+						&& Objects.equals(getPredicate(), other.getPredicate())
+						&& Objects.equals(getObject(), other.getObject());
+			}
+
+			@Override
+			public int hashCode() {
+				return Objects.hash(getSubject(), getPredicate(), getObject());
+			}
+		};
+	}
+
+	/**
+	 * Check it this Quad is equal to another Quad.
+	 * <p>
+	 * Two Quads are equal if and only if their {@link #getGraphName()}, 
+	 * {@link #getSubject()}, {@link #getPredicate()} and 
+	 * {@link #getObject()} are equal.
+	 * </p>
+	 * <p>
+	 * Implementations MUST also override {@link #hashCode()} so that two equal
+	 * Quads produce the same hash code.
+	 * </p>
+	 * <p>
+	 * Note that a {@link Quad} MUST NOT be equal to a 
+	 * {@link Triple}, even if this Quad's {@link #getGraphName()}
+	 * is {@link Optional#empty()}. To test triple-like equivalence, 
+	 * callers can use:
+	 * </p>
+	 * <pre>
+	 * Quad q1;
+	 * Triple t2;
+	 * q1.asTriple().equals(t2));
+	 * </pre>
+	 *
+	 * @param other
+	 *            Another object
+	 * @return true if other is a Quad and is equal to this
+	 * @see Object#equals(Object)
+	 */
+	@Override
+	public boolean equals(Object other);
+
+	/**
+	 * Calculate a hash code for this Quad.
+	 * <p>
+	 * The returned hash code MUST be equal to the result of
+	 * {@link Objects#hash(Object...)} with the arguments {@link #getSubject()},
+	 * {@link #getPredicate()}, {@link #getObject()}, {@link #getGraphName()}.
+	 * <p>
+	 * This method MUST be implemented in conjunction with
+	 * {@link #equals(Object)} so that two equal {@link Quad}s produce the same
+	 * hash code.
+	 *
+	 * @return a hash code value for this Quad.
+	 * @see Object#hashCode()
+	 * @see Objects#hash(Object...)
+	 */
+	@Override
+	public int hashCode();
+
+}

--- a/api/src/main/java/org/apache/commons/rdf/api/QuadLike.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/QuadLike.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.api;
+
+import java.util.Optional;
+
+/**
+ * A generalised "quad-like" interface, extended by {@link Quad}.
+ * <p>
+ * A QuadLike statement has at least a {@link #getSubject()},
+ * {@link #getPredicate()}, {@link #getObject()} and {@link #getGraphName()},
+ * but unlike a {@link Quad} does not have a formalised
+ * {@link Quad#equals(Object)} semantics, and can allow generalised quads (e.g.
+ * a {@link BlankNode} as predicate).
+ * <p>
+ * Implementations should specialise which specific {@link RDFTerm} types they
+ * return for {@link #getSubject()}, {@link #getPredicate()},
+ * {@link #getObject()} and {@link #getGraphName()}.
+ *
+ * @param <S>
+ *            The type of subjects in the statements, typically
+ *            {@link BlankNodeOrIRI}
+ * @param <P>
+ *            The type of predicates in the statements, typically {@link IRI}
+ * @param <O>
+ *            The type of objects in the statements, typically {@link RDFTerm}
+ * @param <G>
+ *            The type of graph names in the statements, typically
+ *            {@link BlankNodeOrIRI}
+ * 
+ * @since 0.3.0-incubating
+ * @see Quad
+ */
+public interface QuadLike<S extends RDFTerm, P extends RDFTerm, O extends RDFTerm, G extends RDFTerm>
+		extends TripleLike<S, P, O> {
+
+	/**
+	 * The graph name (graph label) of this statement, if present.
+	 * <p>
+	 * If {@link Optional#isPresent()}, then the {@link Optional#get()} indicate
+	 * the graph name of this statement. If the graph name is not present,e.g.
+	 * the value is {@link Optional#empty()}, it indicates that this Quad is in
+	 * the default graph.
+	 *
+	 * @return If {@link Optional#isPresent()}, the graph name of this quad,
+	 *         otherwise {@link Optional#empty()}, indicating the default
+	 *         graph. The graph name is typically an {@link IRI} or
+	 *         {@link BlankNode}.
+	 */
+	Optional<G> getGraphName();
+
+}

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFTermFactory.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFTermFactory.java
@@ -99,6 +99,19 @@ public interface RDFTermFactory {
     }
 
     /**
+     * Create a new dataset.
+     *
+     * It is undefined if the dataset will be persisted by any underlying storage
+     * mechanism.
+     *
+     * @return A new Dataset
+     * @throws UnsupportedOperationException If the operation is not supported.
+     */
+    default Dataset createDataset() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException("createDataset() not supported");
+    }
+
+    /**
      * Create an IRI from a (possibly escaped) String.
      *
      * The provided iri string MUST be valid according to the <a
@@ -232,6 +245,33 @@ public interface RDFTermFactory {
             UnsupportedOperationException {
         throw new UnsupportedOperationException(
                 "createTriple(BlankNodeOrIRI,IRI,RDFTerm) not supported");
+    }
+
+    /**
+     * Create a quad.
+     * <p>
+     * The returned Quad SHOULD have a
+     * {@link Quad#getGraphName()} that is equal to the provided graphName, a
+     * {@link Quad#getSubject()} that is
+     * equal to the provided subject, a {@link Quad#getPredicate()} that is
+     * equal to the provided predicate, and a {@link Quad#getObject()} that is
+     * equal to the provided object.
+     *
+     * @param graphName The IRI or BlankNode that this quad belongs to, or <code>null</code> for the default graph
+     * @param subject   The IRI or BlankNode that is the subject of the quad
+     * @param predicate The IRI that is the predicate of the quad
+     * @param object    The IRI, BlankNode or Literal that is the object of the quad
+     * @return The created Quad
+     * @throws IllegalArgumentException      If any of the provided arguments are not acceptable, e.g.
+     *                                       because a Literal has a lexicalForm that is too large for an
+     *                                       underlying storage.
+     * @throws UnsupportedOperationException If the operation is not supported.
+     */
+    default Quad createQuad(BlankNodeOrIRI graphName, BlankNodeOrIRI subject, IRI predicate,
+                                RDFTerm object) throws IllegalArgumentException,
+            UnsupportedOperationException {
+        throw new UnsupportedOperationException(
+                "createQuad(BlankNodeOrIRI,BlankNodeOrIRI,IRI,RDFTerm) not supported");
     }
 
 }

--- a/api/src/main/java/org/apache/commons/rdf/api/Triple.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Triple.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * @see <a href= "http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple" >RDF-1.1
  * Triple</a>
  */
-public interface Triple {
+public interface Triple extends TripleLike<BlankNodeOrIRI, IRI, RDFTerm> {
 
     /**
      * The subject of this triple, which may be either a {@link BlankNode} or an

--- a/api/src/main/java/org/apache/commons/rdf/api/TripleLike.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/TripleLike.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.api;
+
+/**
+ * A generalised "triple-like" interface, extended by {@link Triple} and
+ * {@link Quad}.
+ * <p>
+ * A TripleLike statement has at least a {@link #getSubject()},
+ * {@link #getPredicate()} and {@link #getObject()}, but unlike a {@link Triple}
+ * does not have a formalised {@link Triple#equals(Object)} semantics, and can
+ * allow generalised triples (e.g. a {@link BlankNode} as predicate).
+ * <p>
+ * Implementations should specialise which specific {@link RDFTerm} types they
+ * return for {@link #getSubject()}, {@link #getPredicate()} and
+ * {@link #getObject()}.
+ * 
+ * @param <S>
+ *            The type of subjects in the statements, typically
+ *            {@link BlankNodeOrIRI}
+ * @param <P>
+ *            The type of predicates in the statements, typically {@link IRI}
+ * @param <O>
+ *            The type of objects in the statements, typically {@link RDFTerm}
+ * 
+ * @since 0.3.0-incubating
+ * @see Triple
+ * @see Quad
+ * @see QuadLike
+ */
+public interface TripleLike<S extends RDFTerm, P extends RDFTerm, O extends RDFTerm> {
+
+	/**
+	 * The subject of this statement.
+	 *
+	 * @return The subject, typically an {@link IRI} or {@link BlankNode}.
+	 */
+	S getSubject();
+
+	/**
+	 * The predicate of this statement.
+	 *
+	 * @return The predicate, typically an {@link IRI}.
+	 */
+	P getPredicate();
+
+	/**
+	 * The object of this statement.
+	 *
+	 * @return The object, typically an {@link IRI}, {@link BlankNode} or
+	 *         {@link Literal}.
+	 */
+	O getObject();
+}

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -183,7 +183,7 @@ public abstract class AbstractGraphTest {
 
         assertTrue(graph.contains(alice, knows, bob));
 
-        Optional<? extends Triple> first = graph.getTriples().skip(4)
+        Optional<? extends Triple> first = graph.stream().skip(4)
                 .findFirst();
         Assume.assumeTrue(first.isPresent());
         Triple existingTriple = first.get();
@@ -224,7 +224,7 @@ public abstract class AbstractGraphTest {
         graph.remove(alice, knows, bob);
         assertEquals(shrunkSize, graph.size());
 
-        Optional<? extends Triple> anyTriple = graph.getTriples().findAny();
+        Optional<? extends Triple> anyTriple = graph.stream().findAny();
         Assume.assumeTrue(anyTriple.isPresent());
 
         Triple otherTriple = anyTriple.get();
@@ -248,9 +248,9 @@ public abstract class AbstractGraphTest {
     @Test
     public void getTriples() throws Exception {
 
-        long tripleCount = graph.getTriples().count();
+        long tripleCount = graph.stream().count();
         assertTrue(tripleCount > 0);
-        assertTrue(graph.getTriples().allMatch(t -> graph.contains(t)));
+        assertTrue(graph.stream().allMatch(t -> graph.contains(t)));
         // Check exact count
         Assume.assumeNotNull(bnode1, bnode2, aliceName, bobName, secretClubName,
                 companyName, bobNameTriple);
@@ -260,15 +260,15 @@ public abstract class AbstractGraphTest {
     @Test
     public void getTriplesQuery() throws Exception {
 
-        long aliceCount = graph.getTriples(alice, null, null).count();
+        long aliceCount = graph.stream(alice, null, null).count();
         assertTrue(aliceCount > 0);
         Assume.assumeNotNull(aliceName);
         assertEquals(3, aliceCount);
 
         Assume.assumeNotNull(bnode1, bnode2, bobName, companyName, secretClubName);
-        assertEquals(4, graph.getTriples(null, name, null).count());
+        assertEquals(4, graph.stream(null, name, null).count());
         Assume.assumeNotNull(bnode1);
-        assertEquals(3, graph.getTriples(null, member, null).count());
+        assertEquals(3, graph.stream(null, member, null).count());
     }
 
     @Test
@@ -296,7 +296,7 @@ public abstract class AbstractGraphTest {
             
             // look up BlankNodes by name
             IRI name = factory.createIRI("http://xmlns.com/foaf/0.1/name");
-            g3.getTriples(null, name, null).parallel().forEach( t ->
+            g3.stream(null, name, null).parallel().forEach( t ->
                 whoIsWho.put( t.getObject().ntriplesString(), t.getSubject()));
                         
             assertEquals(4, whoIsWho.size());
@@ -361,7 +361,7 @@ public abstract class AbstractGraphTest {
 
         // unordered() as we don't need to preserve triple order
         // sequential() as we don't (currently) require target Graph to be thread-safe
-        source.getTriples().unordered().sequential().forEach(t -> target.add(t));
+        source.stream().unordered().sequential().forEach(t -> target.add(t));
     }
 
     /**
@@ -459,14 +459,14 @@ public abstract class AbstractGraphTest {
         // Find a secret organizations
         assertEquals(
                 "\"The Secret Club\"",
-                graph.getTriples(null, knows, null)
+                graph.stream(null, knows, null)
                         // Find One-way "knows"
                         .filter(t -> !graph.contains(
                                 (BlankNodeOrIRI) t.getObject(), knows,
                                 t.getSubject()))
                         .map(knowsTriple -> graph
                                 // and those they know, what are they member of?
-                                .getTriples(
+                                .stream(
                                         (BlankNodeOrIRI) knowsTriple
                                                 .getObject(), member, null)
                                         // keep those which first-guy is a member of
@@ -477,7 +477,7 @@ public abstract class AbstractGraphTest {
                                 .get().getObject())
                                 // then look up the name of that org
                         .map(org -> graph
-                                .getTriples((BlankNodeOrIRI) org, name, null)
+                                .stream((BlankNodeOrIRI) org, name, null)
                                 .findFirst().get().getObject().ntriplesString())
                         .findFirst().get());
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>40</version>
+        <version>41</version>
     </parent>
 
     <groupId>org.apache.commons</groupId>

--- a/simple/src/main/java/org/apache/commons/rdf/simple/DatasetGraphView.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/DatasetGraphView.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.simple;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.commons.rdf.api.BlankNode;
+import org.apache.commons.rdf.api.BlankNodeOrIRI;
+import org.apache.commons.rdf.api.Dataset;
+import org.apache.commons.rdf.api.Graph;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Quad;
+import org.apache.commons.rdf.api.RDFTerm;
+import org.apache.commons.rdf.api.Triple;
+
+/**
+ * A {@link Graph} view on a {@link Dataset}.
+ * <p>
+ * This view is backed by a {@link Dataset}, and can be constructed in two ways:
+ * 
+ * <dl>
+ * <dt>{@link #DatasetGraphView(Dataset)}</dt>
+ * <dd>Expose a <em>union graph</em> view of the Dataset, where all the
+ * {@link Quad}s of the Dataset is represented as a {@link Triple}. Adding
+ * triples will add them to the <em>default graph</em>, while removing triples
+ * will remove from all graphs.</dd>
+* 
+ * <dt>{@link #DatasetGraphView(Dataset, BlankNodeOrIRI)}</dt>
+ * <dd>Expose a particular graph of the Dataset, either named by an {@link IRI}, a
+ * {@link BlankNode}, or  <code>null</code> for the <em>default graph</em>.</dd>
+ * </dl>
+ * <p>
+ * Changes in the Graph are reflected directly in the Dataset and vice versa.  
+ * This class is thread-safe is the underlying Dataset is thread-safe.
+ */
+public class DatasetGraphView implements Graph {
+
+	private final boolean unionGraph;
+	private final BlankNodeOrIRI namedGraph;
+	private final Dataset dataset;
+
+	public DatasetGraphView(Dataset dataset) {
+		this.dataset = dataset;
+		this.namedGraph = null;
+		this.unionGraph = true;
+	}
+
+	public DatasetGraphView(Dataset dataset, BlankNodeOrIRI namedGraph) {
+		this.dataset = dataset;
+		this.namedGraph = namedGraph;
+		this.unionGraph = false;
+	}
+
+	@Override
+	public void close() throws Exception {
+		dataset.close();
+
+	}
+
+	@Override
+	public void add(Triple triple) {
+		dataset.add(namedGraph, triple.getSubject(), triple.getPredicate(), triple.getObject());
+	}
+
+	@Override
+	public void add(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+		dataset.add(namedGraph, subject, predicate, object);
+	}
+
+	@Override
+	public boolean contains(Triple triple) {
+		return dataset.contains(unionOrNamedGraph(), triple.getSubject(), triple.getPredicate(), triple.getObject());
+	}
+
+	private Optional<BlankNodeOrIRI> unionOrNamedGraph() {
+		if (unionGraph) {
+			return null;
+		}
+		return Optional.ofNullable(namedGraph);
+	}
+
+	@Override
+	public boolean contains(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+		return dataset.contains(unionOrNamedGraph(), subject, predicate, object);
+	}
+
+	@Override
+	public void remove(Triple triple) {
+		dataset.remove(unionOrNamedGraph(), triple.getSubject(), triple.getPredicate(), triple.getObject());
+	}
+
+	@Override
+	public void remove(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+		dataset.remove(unionOrNamedGraph(), subject, predicate, object);
+	}
+
+	@Override
+	public void clear() {
+		dataset.remove(unionOrNamedGraph(), null, null, null);
+	}
+
+	@Override
+	public long size() {
+		return stream().count();
+	}
+
+	@Override
+	public Stream<? extends Triple> stream() {
+		return stream(null, null, null);
+	}
+
+	@Override
+	public Stream<? extends Triple> stream(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+		Stream<Triple> stream = dataset.stream(unionOrNamedGraph(), subject, predicate, object).map(Quad::asTriple);
+		if (unionGraph) {
+			// remove duplicates
+			return stream.distinct();
+		}
+		return stream;
+	}
+
+}

--- a/simple/src/main/java/org/apache/commons/rdf/simple/DatasetImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/DatasetImpl.java
@@ -1,0 +1,221 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.simple;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.rdf.api.BlankNode;
+import org.apache.commons.rdf.api.BlankNodeOrIRI;
+import org.apache.commons.rdf.api.Dataset;
+import org.apache.commons.rdf.api.Graph;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Literal;
+import org.apache.commons.rdf.api.Quad;
+import org.apache.commons.rdf.api.RDFTerm;
+import org.apache.commons.rdf.simple.SimpleRDFTermFactory.SimpleRDFTerm;
+
+/**
+ * A simple, memory-based implementation of Dataset.
+ * <p>
+ * {@link Quad}s in the graph are kept in a {@link Set}.
+ * <p>
+ * All Stream operations are performed using parallel and unordered directives.
+ */
+final class DatasetImpl implements Dataset {
+	
+    private static final int TO_STRING_MAX = 10;
+    private final Set<Quad> quads = new HashSet<Quad>();
+    private final SimpleRDFTermFactory factory;
+
+    DatasetImpl(SimpleRDFTermFactory simpleRDFTermFactory) {
+        this.factory = simpleRDFTermFactory;
+    }
+    
+	@Override
+	public void add(BlankNodeOrIRI graphName, BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+		BlankNodeOrIRI newGraphName = (BlankNodeOrIRI) internallyMap(graphName);
+		BlankNodeOrIRI newSubject = (BlankNodeOrIRI) internallyMap(subject);
+        IRI newPredicate = (IRI) internallyMap(predicate);
+        RDFTerm newObject = internallyMap(object);
+        Quad result = factory.createQuad(newGraphName, newSubject, newPredicate, newObject);
+        quads.add(result);
+	}    
+
+    @Override
+    public void add(Quad quad) {    	
+    	BlankNodeOrIRI newGraph = (BlankNodeOrIRI) internallyMap(quad.getGraphName().orElse(null));
+    	BlankNodeOrIRI newSubject = (BlankNodeOrIRI) internallyMap(quad
+                .getSubject());        
+        IRI newPredicate = (IRI) internallyMap(quad.getPredicate());
+        RDFTerm newObject = internallyMap(quad.getObject());
+        // Check if any of the object references changed during the mapping, to
+        // avoid creating a new Quad object if possible
+        if (newGraph == quad.getGraphName().orElse(null) 
+        	&& newSubject == quad.getSubject()
+            && newPredicate == quad.getPredicate()
+            && newObject == quad.getObject()) {
+            quads.add(quad);
+        } else {
+        	// Make a new Quad with our mapped instances
+            Quad result = factory.createQuad(newGraph, newSubject, newPredicate,
+                    newObject);
+            quads.add(result);
+        }
+    }
+
+    private <T extends RDFTerm> RDFTerm internallyMap(T object) {
+    	if (object == null || object instanceof SimpleRDFTerm) {
+    		return object;
+    	}    	
+        if (object instanceof BlankNode && !(object instanceof BlankNodeImpl)) {
+            BlankNode blankNode = (BlankNode) object;
+            // This guarantees that adding the same BlankNode multiple times to
+            // this graph will generate a local object that is mapped to an
+            // equivalent object, based on the code in the package private
+            // BlankNodeImpl class
+            return factory.createBlankNode(blankNode.uniqueReference());
+        } else if (object instanceof IRI && !(object instanceof IRIImpl)) {
+            IRI iri = (IRI) object;
+            return factory.createIRI(iri.getIRIString());
+        } else if (object instanceof Literal
+                && !(object instanceof LiteralImpl)) {
+            Literal literal = (Literal) object;
+            if (literal.getLanguageTag().isPresent()) {
+                return factory.createLiteral(literal.getLexicalForm(), literal
+                        .getLanguageTag().get());
+            } else {
+                return factory.createLiteral(literal.getLexicalForm(),
+                        (IRI) internallyMap(literal.getDatatype()));
+            }
+        } else {
+        	throw new IllegalArgumentException("Not a BlankNode, IRI or Literal: " + object);
+        }
+    }
+
+    @Override
+    public void clear() {
+        quads.clear();
+    }
+
+	@Override
+	public boolean contains(Optional<BlankNodeOrIRI> graphName, BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+		return stream(graphName, subject, predicate, object).findAny().isPresent();
+	}
+    
+    @Override
+    public boolean contains(Quad quad) {
+        return quads.contains(Objects.requireNonNull(quad));
+    }
+    
+	@Override
+	public Stream<Quad> stream() {
+        return quads.parallelStream().unordered();
+	}
+
+	@Override
+	public Stream<Quad> stream(Optional<BlankNodeOrIRI> graphName, BlankNodeOrIRI subject, IRI predicate,
+			RDFTerm object) {
+		final Optional<BlankNodeOrIRI> newGraphName = graphName.map(g -> (BlankNodeOrIRI)internallyMap(g));
+        final BlankNodeOrIRI newSubject = (BlankNodeOrIRI) internallyMap(subject);
+        final IRI newPredicate = (IRI) internallyMap(predicate);
+        final RDFTerm newObject = internallyMap(object);
+
+        return getQuads(t -> {
+            if (newGraphName != null && !t.getGraphName().equals(newGraphName)) {
+            	// This would check Optional.empty() == Optional.empty()
+                return false;
+            }        	
+            if (subject != null && !t.getSubject().equals(newSubject)) {
+                return false;
+            }
+            if (predicate != null && !t.getPredicate().equals(newPredicate)) {
+                return false;
+            }
+            if (object != null && !t.getObject().equals(newObject)) {
+                return false;
+            }
+            return true;
+        });
+	}    
+
+    private Stream<Quad> getQuads(final Predicate<Quad> filter) {
+        return stream().filter(filter);
+    }
+
+	@Override
+	public void remove(Optional<BlankNodeOrIRI> graphName, BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+        Stream<Quad> toRemove = stream(graphName, subject, predicate, object);
+        for (Quad t : toRemove.collect(Collectors.toList())) {
+            // Avoid ConcurrentModificationException in ArrayList
+            remove(t);
+        }
+	}
+
+    @Override
+    public void remove(Quad quad) {
+        quads.remove(Objects.requireNonNull(quad));
+    }
+
+    @Override
+    public long size() {
+        return quads.size();
+    }
+
+    @Override
+    public String toString() {
+        String s = stream().limit(TO_STRING_MAX).map(Object::toString)
+                .collect(Collectors.joining("\n"));
+        if (size() > TO_STRING_MAX) {
+            return s + "\n# ... +" + (size() - TO_STRING_MAX) + " more";
+        } else {
+            return s;
+        }
+    }
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public Graph getGraph() {
+		return getGraph(null).get();
+	}
+
+	@Override
+	public Optional<Graph> getGraph(BlankNodeOrIRI graphName) {
+		return Optional.of(new DatasetGraphView(this, graphName));
+	}
+
+	@Override
+	public Stream<BlankNodeOrIRI> getGraphNames() {
+		// Not very efficient..
+		return stream()
+				.map(Quad::getGraphName)
+				.filter(Optional::isPresent).map(Optional::get)
+				.distinct();
+	}
+
+
+
+}

--- a/simple/src/main/java/org/apache/commons/rdf/simple/GraphImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/GraphImpl.java
@@ -111,7 +111,7 @@ final class GraphImpl implements Graph {
     @Override
     public boolean contains(BlankNodeOrIRI subject, IRI predicate,
                             RDFTerm object) {
-        return getTriples(subject, predicate, object).findFirst().isPresent();
+        return stream(subject, predicate, object).findFirst().isPresent();
     }
 
     @Override
@@ -120,12 +120,12 @@ final class GraphImpl implements Graph {
     }
 
     @Override
-    public Stream<Triple> getTriples() {
+    public Stream<Triple> stream() {
         return triples.parallelStream().unordered();
     }
 
     @Override
-    public Stream<Triple> getTriples(final BlankNodeOrIRI subject,
+    public Stream<Triple> stream(final BlankNodeOrIRI subject,
                                      final IRI predicate, final RDFTerm object) {
         final BlankNodeOrIRI newSubject = (BlankNodeOrIRI) internallyMap(subject);
         final IRI newPredicate = (IRI) internallyMap(predicate);
@@ -148,12 +148,12 @@ final class GraphImpl implements Graph {
     }
 
     private Stream<Triple> getTriples(final Predicate<Triple> filter) {
-        return getTriples().filter(filter);
+        return stream().filter(filter);
     }
 
     @Override
     public void remove(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-        Stream<Triple> toRemove = getTriples(subject, predicate, object);
+        Stream<Triple> toRemove = stream(subject, predicate, object);
         for (Triple t : toRemove.collect(Collectors.toList())) {
             // Avoid ConcurrentModificationException in ArrayList
             remove(t);
@@ -172,7 +172,7 @@ final class GraphImpl implements Graph {
 
     @Override
     public String toString() {
-        String s = getTriples().limit(TO_STRING_MAX).map(Object::toString)
+        String s = stream().limit(TO_STRING_MAX).map(Object::toString)
                 .collect(Collectors.joining("\n"));
         if (size() > TO_STRING_MAX) {
             return s + "\n# ... +" + (size() - TO_STRING_MAX) + " more";

--- a/simple/src/main/java/org/apache/commons/rdf/simple/QuadImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/QuadImpl.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.simple;
+
+import org.apache.commons.rdf.api.BlankNodeOrIRI;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Quad;
+import org.apache.commons.rdf.api.RDFTerm;
+import org.apache.commons.rdf.api.Triple;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A simple implementation of Quad.
+ */
+final class QuadImpl implements Quad {
+
+	private final BlankNodeOrIRI graphName;
+    private final BlankNodeOrIRI subject;
+    private final IRI predicate;
+    private final RDFTerm object;
+
+    /**
+     * Construct Quad from its constituent parts.
+     * <p>
+     * The objects are not changed. All mapping of BNode objects is done in
+     * {@link SimpleRDFTermFactory#createQuad(BlankNodeOrIRI, BlankNodeOrIRI, IRI, RDFTerm)}.
+     *
+     * @param graphName  graphName of triple
+     * @param subject   subject of triple
+     * @param predicate predicate of triple
+     * @param object    object of triple
+     */
+    public QuadImpl(BlankNodeOrIRI graphName, BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+    	this.graphName = graphName; // possibly null
+        this.subject = Objects.requireNonNull(subject);
+        this.predicate = Objects.requireNonNull(predicate);
+        this.object = Objects.requireNonNull(object);
+    }
+
+    @Override
+    public Optional<BlankNodeOrIRI> getGraphName() {
+    	return Optional.ofNullable(graphName);
+    }
+    
+    @Override
+    public BlankNodeOrIRI getSubject() {
+        return subject;
+    }
+
+    @Override
+    public IRI getPredicate() {
+        return predicate;
+    }
+
+    @Override
+    public RDFTerm getObject() {
+        return object;
+    }
+
+    @Override
+    public String toString() {    	
+        return 
+			getSubject().ntriplesString() + " "
+	        + getPredicate().ntriplesString() + " "
+	        + getObject().ntriplesString() + " " 
+	        + getGraphName().map(g -> g.ntriplesString() + " ").orElse("")
+	        + ".";    	
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subject, predicate, object, graphName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Quad)) {
+            return false;
+        }
+        Quad other = (Quad) obj;
+        return getGraphName().equals(other.getGraphName()) 
+        		&& getSubject().equals(other.getSubject())
+                && getPredicate().equals(other.getPredicate())
+                && getObject().equals(other.getObject());
+    }
+    
+    @Override
+    public Triple asTriple() {
+    	return new TripleImpl(getSubject(), getPredicate(), getObject());
+    }
+
+}

--- a/simple/src/main/java/org/apache/commons/rdf/simple/SimpleRDFTermFactory.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/SimpleRDFTermFactory.java
@@ -21,9 +21,11 @@ import java.util.UUID;
 
 import org.apache.commons.rdf.api.BlankNode;
 import org.apache.commons.rdf.api.BlankNodeOrIRI;
+import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Literal;
+import org.apache.commons.rdf.api.Quad;
 import org.apache.commons.rdf.api.RDFTerm;
 import org.apache.commons.rdf.api.RDFTermFactory;
 import org.apache.commons.rdf.api.Triple;
@@ -71,6 +73,11 @@ public class SimpleRDFTermFactory implements RDFTermFactory {
     }
 
     @Override
+    public Dataset createDataset() throws UnsupportedOperationException {
+    	return new DatasetImpl(this);
+    }
+    
+    @Override
     public IRI createIRI(String iri) {
         IRI result = new IRIImpl(iri);
         // Reuse any IRI objects already created in Types
@@ -96,5 +103,11 @@ public class SimpleRDFTermFactory implements RDFTermFactory {
     public Triple createTriple(BlankNodeOrIRI subject, IRI predicate,
                                RDFTerm object) {
         return new TripleImpl(subject, predicate, object);
+    }
+    
+    @Override
+    public Quad createQuad(BlankNodeOrIRI graphName, BlankNodeOrIRI subject, IRI predicate, RDFTerm object)
+    		throws IllegalArgumentException, UnsupportedOperationException {
+    	return new QuadImpl(graphName, subject, predicate, object);
     }
 }

--- a/simple/src/test/java/org/apache/commons/rdf/simple/TestWritingGraph.java
+++ b/simple/src/test/java/org/apache/commons/rdf/simple/TestWritingGraph.java
@@ -102,7 +102,7 @@ public class TestWritingGraph {
     public void countQuery() {
         IRI subject = factory.createIRI("subj");
         IRI predicate = factory.createIRI("pred");
-        long count = graph.getTriples(subject, predicate, null).unordered()
+        long count = graph.stream(subject, predicate, null).unordered()
                 .parallel().count();
         //System.out.println("Counted - " + count);
         assertEquals(count, TRIPLES);
@@ -123,7 +123,7 @@ public class TestWritingGraph {
             graphFile.toFile().deleteOnExit();
         }
 
-        Stream<CharSequence> stream = graph.getTriples().map(TestWritingGraph::tripleAsString);
+        Stream<CharSequence> stream = graph.stream().map(TestWritingGraph::tripleAsString);
         Files.write(graphFile, stream::iterator, StandardCharsets.UTF_8);
     }
 
@@ -139,7 +139,7 @@ public class TestWritingGraph {
         IRI subject = factory.createIRI("subj");
         IRI predicate = factory.createIRI("pred");
         Stream<CharSequence> stream = graph
-                .getTriples(subject, predicate, null).map(TestWritingGraph::tripleAsString);
+                .stream(subject, predicate, null).map(TestWritingGraph::tripleAsString);
         Files.write(graphFile, stream::iterator, StandardCharsets.UTF_8);
 
     }
@@ -156,7 +156,7 @@ public class TestWritingGraph {
         IRI subject = factory.createIRI("nonexistent");
         IRI predicate = factory.createIRI("pred");
         Stream<CharSequence> stream = graph
-                .getTriples(subject, predicate, null).map(Object::toString);
+                .stream(subject, predicate, null).map(Object::toString);
         Files.write(graphFile, stream::iterator, StandardCharsets.UTF_8);
 
     }


### PR DESCRIPTION
As [discussed on dev](http://mail-archives.apache.org/mod_mbox/incubator-commonsrdf-dev/201604.mbox/%3CCAMBJEmVTP27fb-sxqTgJgJ5YP6ZKAjaWobOpWiyTbE%2BOPfODtw%40mail.gmail.com%3E) it would be good to have a `Quad` and `Dataset` types added, corresponding to the [RDF concept Dataset](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset) and [Quad semantics](https://www.w3.org/TR/2014/NOTE-rdf11-datasets-20140225/#quad-semantics).

Generated Javadocs from this branch of the new interfaces:

http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/Quad.html
http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/Dataset.html
http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/GraphOrDataset.html
http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/TripleOrQuad.html

The discussion on dev concluded that although Quad looks like Triple (`getSubject()` `getPredicate()` and `getObject()` - a Quad necessarily have different `.equals()` semantics. Allowing a Quad to pretend it is a Triple leads to some murky equivalence questions - so instead this branch rather makes a common interface `TripleOrQuad` (modelled after `BlankNodeOrIRI`) which contains the subject/predicate/object methods - while `Triple` and `Quad` have different equals - that is [Quad.equals](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/Quad.html#equals-java.lang.Object-) require to also match on [getGraphName](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/Quad.html#getGraphName--).

I modelled [getGraphName](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/Quad.html#getGraphName--) as an `Optional<BlankNodeOrIRI` - where `Optional.empty()` represents the default graph.  An alternative would be to make a `DEFAULT_GRAPH` BlankNodeOrIRI constant -- but should this have a `ntriplesString()==null` - or would we need yet another upper interface, `BlankNodeOrIRIOrDefaultGraph` ? 

The use of `Optional` makes it a bit inconsistent in `Dataset` if we also follow the advice that `Optional` should not normally appear as a parameter argument -  - [Dataset.add](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/Dataset.html#add-org.apache.commons.rdf.api.BlankNodeOrIRI-org.apache.commons.rdf.api.BlankNodeOrIRI-org.apache.commons.rdf.api.IRI-org.apache.commons.rdf.api.RDFTerm-) uses `graphName=null` to indicate the default graph - while in [contains](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/Dataset.html#contains-java.util.Optional-org.apache.commons.rdf.api.BlankNodeOrIRI-org.apache.commons.rdf.api.IRI-org.apache.commons.rdf.api.RDFTerm-) and [remove](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/Dataset.html#remove-java.util.Optional-org.apache.commons.rdf.api.BlankNodeOrIRI-org.apache.commons.rdf.api.IRI-org.apache.commons.rdf.api.RDFTerm-) we use `null` as a wildcard, and `Optional.empty()` to mean the empty graph.

If we also have an equivalent common interface [GraphOrDataset](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/GraphOrDataset.html) - and allow the expanded filter methods in there, then those would operate on the default graph in the Dataset.  Thus you would have two routes to filter on the default graph.

We can reduce which methods should be included in GraphOrDataset - to only have the generic `T`-typed methods - and not force [getTriples()](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/GraphOrDataset.html#getTriples--) onto Dataset - where it would need to call [Quad.asTriple](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/Quad.html#asTriple--) to return `Triple` instances.

## Upper interfaces

The two "ducktyping" interfaces [GraphOrDataset](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/GraphOrDataset.html) and [TripleOrQuad](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/TripleOrQuad.html) could be removed as their signatures are duplicated in `Graph` and `Dataset` - I intended them for any kind of generic usage that can handle both Graph and Dataset - e.g. parsers and serializers.

[TripleOrQuad](http://stain.github.io/incubator-commonsrdf/quad/org/apache/commons/rdf/api/TripleOrQuad.html) could be generalized to return `RDFTerm` on all of `getSubject()`, `getPredicate()` and `getObject()` - I know both Jena and JSON-LD can potentially have generalized RDF triples. But this could be out of scope and force additional casting for anyone using `TripleOrQuad` interface.