### PR TITLE
Added SimpleRDFTerm marker interface

### DIFF
--- a/simple/src/main/java/org/apache/commons/rdf/simple/BlankNodeImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/BlankNodeImpl.java
@@ -23,11 +23,12 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.rdf.api.BlankNode;
+import org.apache.commons.rdf.simple.SimpleRDFTermFactory.SimpleRDFTerm;
 
 /**
  * A simple implementation of BlankNode.
  */
-final class BlankNodeImpl implements BlankNode {
+final class BlankNodeImpl implements BlankNode, SimpleRDFTerm {
 
     private static final UUID SALT = UUID.randomUUID();
     private static final AtomicLong COUNTER = new AtomicLong();

--- a/simple/src/main/java/org/apache/commons/rdf/simple/IRIImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/IRIImpl.java
@@ -24,7 +24,7 @@ import java.net.URI;
 /**
  * A simple implementation of IRI.
  */
-final class IRIImpl implements IRI {
+final class IRIImpl implements IRI, SimpleRDFTermFactory.SimpleRDFTerm {
 
     private final String iri;
 

--- a/simple/src/main/java/org/apache/commons/rdf/simple/LiteralImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/LiteralImpl.java
@@ -28,7 +28,7 @@ import org.apache.commons.rdf.api.Literal;
 /**
  * A simple implementation of Literal.
  */
-final class LiteralImpl implements Literal {
+final class LiteralImpl implements Literal, SimpleRDFTermFactory.SimpleRDFTerm {
 
     private static final String QUOTE = "\"";
 

--- a/simple/src/main/java/org/apache/commons/rdf/simple/SimpleRDFTermFactory.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/SimpleRDFTermFactory.java
@@ -37,6 +37,18 @@ import org.apache.commons.rdf.api.Triple;
  */
 public class SimpleRDFTermFactory implements RDFTermFactory {
 
+	/**
+	 * Marker interface to say that this RDFTerm is part of the 
+	 * Simple implementation. Used by {@link GraphImpl} to avoid
+	 * double remapping. 
+	 * <p>
+	 * This method is package protected to avoid any third-party
+	 * subclasses.
+	 *
+	 */
+	static interface SimpleRDFTerm extends RDFTerm {		
+	}
+	
     /** Unique salt per instance, for {@link #createBlankNode(String)}
      */
     private final UUID SALT = UUID.randomUUID();

--- a/simple/src/main/java/org/apache/commons/rdf/simple/Types.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/Types.java
@@ -27,7 +27,7 @@ import java.util.Set;
 /**
  * Types from the RDF and XML Schema vocabularies.
  */
-public final class Types implements IRI {
+public final class Types implements IRI, SimpleRDFTermFactory.SimpleRDFTerm {
 
     /**
      * <tt>http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML</tt>


### PR DESCRIPTION
Now internallyMap() will fail early on mapping
any RDFTerm objects which are not IRI, BlankNode or Literal
(before they would have been added 'as-is')

This also fixes a bug in that Graph would have remapped
any of the Types instances to an IRIImpl.

I added SimpleRDFTerm interface as a package-protected
interface within SimpleRDFTermFactory - thus it should not
be easy to create any additional SimpleRDFTerm subclasses.