### PR TITLE
Add RDFParserBuilder interface

### DIFF
--- a/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
@@ -145,15 +145,15 @@ public interface RDFParserBuilder {
 	 * <code>@base</code> in Turtle documents).
 	 * <p>
 	 * If the source is in a syntax that does not support relative IRI
-	 * references, e.g. {@link RDFSyntax#NTRIPLES}, setting the base has no
-	 * effect.
+	 * references (e.g. {@link RDFSyntax#NTRIPLES}), setting the 
+	 * <code>base</code> has no effect.
 	 * <p>
 	 * This method will override any base IRI set with {@link #base(String)}.
 	 *
 	 * @see #base(String)
 	 * @param base
-	 *            An absolute IRI to use as a base
-	 * @return An {@link RDFParserBuilder} that will use the specified base IRI
+	 *            An absolute IRI to use as a base.
+	 * @return An {@link RDFParserBuilder} that will use the specified base IRI.
 	 */
 	RDFParserBuilder base(IRI base);
 
@@ -166,37 +166,41 @@ public interface RDFParserBuilder {
 	 * <code>@base</code> in Turtle documents).
 	 * <p>
 	 * If the source is in a syntax that does not support relative IRI
-	 * references, e.g. {@link RDFSyntax#NTRIPLES}, setting the base has no
-	 * effect.
+	 * references (e.g. {@link RDFSyntax#NTRIPLES}), setting the 
+	 * <code>base</code> has no effect.
 	 * <p>
 	 * This method will override any base IRI set with {@link #base(IRI)}.
 	 *
 	 * @see #base(IRI)
 	 * @param base
-	 *            An absolute IRI to use as a base
-	 * @return An {@link RDFParserBuilder} that will use the specified base IRI
+	 *            An absolute IRI to use as a base.
+	 * @return An {@link RDFParserBuilder} that will use the specified base IRI.
 	 */
 	RDFParserBuilder base(String base);
 
 	/**
-	 * Specify a source to parse.
+	 * Specify a source {@link InputStream} to parse.
 	 * <p>
 	 * The source set will not be read before the call to {@link #parse()}.
 	 * <p>
 	 * The InputStream will not be closed after parsing. The InputStream does
-	 * not need to support {@link InputStream#markSupported()}. The parser might
-	 * not consume the complete stream (e.g. the parser may not read beyond the
-	 * closing tag of <code>&lt;/rdf:Description&;gt</code>).
+	 * not need to support {@link InputStream#markSupported()}. 
+	 * <p>
+	 * The parser might
+	 * not consume the complete stream (e.g. an RDF/XML parser may not read beyond the
+	 * closing tag of <code>&lt;/rdf:Description&gt;</code>).
 	 * <p>
 	 * The {@link #contentType(RDFSyntax)} or {@link #contentType(String)}
 	 * SHOULD be set before calling {@link #parse()}.
 	 * <p>
 	 * The character set is assumed to be {@link StandardCharsets#UTF_8} unless
-	 * the {@link #contentType(String)} specifies otherwise.
+	 * the {@link #contentType(String)} specifies otherwise or the document
+	 * declares its own charset (e.g. RDF/XML with a 
+	 * <code>&lt;?xml encoding="iso-8859-1"&gt;</code> header).
 	 * <p>
 	 * The {@link #base(IRI)} or {@link #base(String)} MUST be set before
-	 * calling {@link #parse()}, unless the syntax does not permit relative
-	 * IRIs.
+	 * calling {@link #parse()}, unless the RDF syntax does not permit relative
+	 * IRIs (e.g. {@link RDFSyntax#NTRIPLES}).
 	 * <p>
 	 * This method will override any source set with {@link #source(IRI)},
 	 * {@link #source(Path)} or {@link #source(String)}.
@@ -207,10 +211,96 @@ public interface RDFParserBuilder {
 	 */
 	RDFParserBuilder source(InputStream inputStream);
 
+	/**
+	 * Specify a source file {@link Path} to parse.
+	 * <p>
+	 * The source set will not be read before the call to {@link #parse()}.
+	 * <p>
+	 * The {@link #contentType(RDFSyntax)} or {@link #contentType(String)}
+	 * SHOULD be set before calling {@link #parse()}. 
+	 * <p>
+	 * The character set is assumed to be {@link StandardCharsets#UTF_8} unless
+	 * the {@link #contentType(String)} specifies otherwise or the document
+	 * declares its own charset (e.g. RDF/XML with a 
+	 * <code>&lt;?xml encoding="iso-8859-1"&gt;</code> header).
+	 * <p>
+	 * The {@link #base(IRI)} or {@link #base(String)} MAY be set before
+	 * calling {@link #parse()}, otherwise {@link Path#toUri()} will be used
+	 * as the base IRI.
+	 * <p>
+	 * This method will override any source set with {@link #source(IRI)},
+	 * {@link #source(InputStream)} or {@link #source(String)}.
+	 * 
+	 * @param file
+	 *            A Path for a file to parse
+	 * @return An {@link RDFParserBuilder} that will use the specified source.
+	 */
 	RDFParserBuilder source(Path file);
 
+	/**
+	 * Specify an absolute source {@link IRI} to retrieve and parse.
+	 * <p>
+	 * The source set will not be read before the call to {@link #parse()}.
+	 * <p>
+	 * If this builder does not support the given IRI 
+	 * (e.g. <code>urn:uuid:ce667463-c5ab-4c23-9b64-701d055c4890</code>),
+	 * this method should succeed, while the {@link #parse()} should 
+	 * throw an {@link IOException}. 
+	 * <p>
+	 * The {@link #contentType(RDFSyntax)} or {@link #contentType(String)}
+	 * MAY be set before calling {@link #parse()}, in which case that
+	 * type MAY be used for content negotiation (e.g. <code>Accept</code> header in HTTP),
+	 * and SHOULD be used for selecting the RDFSyntax.
+	 * <p>
+	 * The character set is assumed to be {@link StandardCharsets#UTF_8} unless
+	 * the protocol's equivalent of <code>Content-Type</code> specifies otherwise or
+	 * the document declares its own charset (e.g. RDF/XML with a 
+	 * <code>&lt;?xml encoding="iso-8859-1"&gt;</code> header).
+	 * <p>
+	 * The {@link #base(IRI)} or {@link #base(String)} MAY be set before
+	 * calling {@link #parse()}, otherwise the source IRI will be used
+	 * as the base IRI.
+	 * <p>
+	 * This method will override any source set with {@link #source(Path)},
+	 * {@link #source(InputStream)} or {@link #source(String)}.
+	 * 
+	 * @param iri
+	 *            An IRI to retrieve and parse
+	 * @return An {@link RDFParserBuilder} that will use the specified source.
+	 */
 	RDFParserBuilder source(IRI iri);
 
+	/**
+	 * Specify an absolute source IRI to retrieve and parse.
+	 * <p>
+	 * The source set will not be read before the call to {@link #parse()}.
+	 * <p>
+	 * If this builder does not support the given IRI 
+	 * (e.g. <code>urn:uuid:ce667463-c5ab-4c23-9b64-701d055c4890</code>),
+	 * this method should succeed, while the {@link #parse()} should 
+	 * throw an {@link IOException}. 
+	 * <p>
+	 * The {@link #contentType(RDFSyntax)} or {@link #contentType(String)}
+	 * MAY be set before calling {@link #parse()}, in which case that
+	 * type MAY be used for content negotiation (e.g. <code>Accept</code> header in HTTP),
+	 * and SHOULD be used for selecting the RDFSyntax.
+	 * <p>
+	 * The character set is assumed to be {@link StandardCharsets#UTF_8} unless
+	 * the protocol's equivalent of <code>Content-Type</code> specifies otherwise or
+	 * the document declares its own charset (e.g. RDF/XML with a 
+	 * <code>&lt;?xml encoding="iso-8859-1"&gt;</code> header).
+	 * <p>
+	 * The {@link #base(IRI)} or {@link #base(String)} MAY be set before
+	 * calling {@link #parse()}, otherwise the source IRI will be used
+	 * as the base IRI.
+	 * <p>
+	 * This method will override any source set with {@link #source(Path)},
+	 * {@link #source(InputStream)} or {@link #source(IRI)}.
+	 * 
+	 * @param iri
+	 *            An IRI to retrieve and parse
+	 * @return An {@link RDFParserBuilder} that will use the specified source.
+	 */	
 	RDFParserBuilder source(String iri);
 
 	/**

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
@@ -29,8 +29,8 @@ import java.util.concurrent.Future;
  * This interface follows the
  * <a href="https://en.wikipedia.org/wiki/Builder_pattern">Builder pattern</a>,
  * allowing to set parser settings like {@link #contentType(RDFSyntax)} and
- * {@link #base(IRI)}. A caller MUST at least call one of the
- * <code>source</code> methods before calling {@link #parse()} on the returned
+ * {@link #base(IRI)}. A caller MUST call one of the
+ * {@link #source(IRI)} methods before calling {@link #parse()} on the returned
  * RDFParserBuilder.
  * <p>
  * It is undefined if a RDFParserBuilder is mutable or thread-safe, so callers
@@ -98,8 +98,8 @@ public interface RDFParserBuilder {
 	 * any <code>Content-Type</code> headers or equivalent.
 	 * <p>
 	 * The content type MAY include a <code>charset</code> parameter if the RDF
-	 * media types which permit it; if <code>charset</code> is not specified the
-	 * default is {@link StandardCharsets#UTF_8} unless overridden within the
+	 * media types permit it; the default charset 
+	 * is {@link StandardCharsets#UTF_8} unless overridden within the
 	 * document.
 	 * <p>
 	 * This method will override any contentType set with
@@ -112,21 +112,22 @@ public interface RDFParserBuilder {
 	 *            <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">
 	 *            RFC7231</a>.
 	 * @throws IllegalArgumentException
-	 *             If this RDFParserBuilder does not support the specified
-	 *             content-type, or it has an invalid syntax.
+	 *             If the contentType has an invalid syntax, 
+	 *             or this RDFParserBuilder does not support the specified
+	 *             contentType.
 	 * @return An {@link RDFParserBuilder} that will use the specified content
 	 *         type.
 	 */
 	RDFParserBuilder contentType(String contentType);
 
 	/**
-	 * Specify which {@link Graph} to add triples into.
+	 * Specify which {@link Graph} to add triples to.
 	 * <p>
-	 * The default if this option has not been set is that each call to
-	 * {@link #parse()} will return a new {@link Graph} (created using
+	 * The default (if this option has not been set) is that each call to
+	 * {@link #parse()} return a new {@link Graph}, which is created using
 	 * {@link RDFTermFactory#createGraph()} 
 	 * if {@link #rdfTermFactory(RDFTermFactory)}
-	 * has been set).
+	 * has been set.
 	 * 
 	 * @param graph
 	 *            The {@link Graph} to add triples into.

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
@@ -29,9 +29,8 @@ import java.util.concurrent.Future;
  * This interface follows the
  * <a href="https://en.wikipedia.org/wiki/Builder_pattern">Builder pattern</a>,
  * allowing to set parser settings like {@link #contentType(RDFSyntax)} and
- * {@link #base(IRI)}. A caller MUST call one of the
- * {@link #source(IRI)} methods before calling {@link #parse()} on the returned
- * RDFParserBuilder.
+ * {@link #base(IRI)}. A caller MUST call one of the {@link #source(IRI)}
+ * methods before calling {@link #parse()} on the returned RDFParserBuilder.
  * <p>
  * It is undefined if a RDFParserBuilder is mutable or thread-safe, so callers
  * should always use the returned modified RDFParserBuilder from the builder
@@ -98,9 +97,8 @@ public interface RDFParserBuilder {
 	 * any <code>Content-Type</code> headers or equivalent.
 	 * <p>
 	 * The content type MAY include a <code>charset</code> parameter if the RDF
-	 * media types permit it; the default charset 
-	 * is {@link StandardCharsets#UTF_8} unless overridden within the
-	 * document.
+	 * media types permit it; the default charset is
+	 * {@link StandardCharsets#UTF_8} unless overridden within the document.
 	 * <p>
 	 * This method will override any contentType set with
 	 * {@link #contentType(RDFSyntax)}.
@@ -112,9 +110,8 @@ public interface RDFParserBuilder {
 	 *            <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">
 	 *            RFC7231</a>.
 	 * @throws IllegalArgumentException
-	 *             If the contentType has an invalid syntax, 
-	 *             or this RDFParserBuilder does not support the specified
-	 *             contentType.
+	 *             If the contentType has an invalid syntax, or this
+	 *             RDFParserBuilder does not support the specified contentType.
 	 * @return An {@link RDFParserBuilder} that will use the specified content
 	 *         type.
 	 */
@@ -125,9 +122,8 @@ public interface RDFParserBuilder {
 	 * <p>
 	 * The default (if this option has not been set) is that each call to
 	 * {@link #parse()} return a new {@link Graph}, which is created using
-	 * {@link RDFTermFactory#createGraph()} 
-	 * if {@link #rdfTermFactory(RDFTermFactory)}
-	 * has been set.
+	 * {@link RDFTermFactory#createGraph()} if
+	 * {@link #rdfTermFactory(RDFTermFactory)} has been set.
 	 * 
 	 * @param graph
 	 *            The {@link Graph} to add triples into.
@@ -145,7 +141,7 @@ public interface RDFParserBuilder {
 	 * <code>@base</code> in Turtle documents).
 	 * <p>
 	 * If the source is in a syntax that does not support relative IRI
-	 * references (e.g. {@link RDFSyntax#NTRIPLES}), setting the 
+	 * references (e.g. {@link RDFSyntax#NTRIPLES}), setting the
 	 * <code>base</code> has no effect.
 	 * <p>
 	 * This method will override any base IRI set with {@link #base(String)}.
@@ -166,7 +162,7 @@ public interface RDFParserBuilder {
 	 * <code>@base</code> in Turtle documents).
 	 * <p>
 	 * If the source is in a syntax that does not support relative IRI
-	 * references (e.g. {@link RDFSyntax#NTRIPLES}), setting the 
+	 * references (e.g. {@link RDFSyntax#NTRIPLES}), setting the
 	 * <code>base</code> has no effect.
 	 * <p>
 	 * This method will override any base IRI set with {@link #base(IRI)}.
@@ -184,18 +180,18 @@ public interface RDFParserBuilder {
 	 * The source set will not be read before the call to {@link #parse()}.
 	 * <p>
 	 * The InputStream will not be closed after parsing. The InputStream does
-	 * not need to support {@link InputStream#markSupported()}. 
+	 * not need to support {@link InputStream#markSupported()}.
 	 * <p>
-	 * The parser might
-	 * not consume the complete stream (e.g. an RDF/XML parser may not read beyond the
-	 * closing tag of <code>&lt;/rdf:Description&gt;</code>).
+	 * The parser might not consume the complete stream (e.g. an RDF/XML parser
+	 * may not read beyond the closing tag of
+	 * <code>&lt;/rdf:Description&gt;</code>).
 	 * <p>
 	 * The {@link #contentType(RDFSyntax)} or {@link #contentType(String)}
 	 * SHOULD be set before calling {@link #parse()}.
 	 * <p>
 	 * The character set is assumed to be {@link StandardCharsets#UTF_8} unless
 	 * the {@link #contentType(String)} specifies otherwise or the document
-	 * declares its own charset (e.g. RDF/XML with a 
+	 * declares its own charset (e.g. RDF/XML with a
 	 * <code>&lt;?xml encoding="iso-8859-1"&gt;</code> header).
 	 * <p>
 	 * The {@link #base(IRI)} or {@link #base(String)} MUST be set before
@@ -217,16 +213,16 @@ public interface RDFParserBuilder {
 	 * The source set will not be read before the call to {@link #parse()}.
 	 * <p>
 	 * The {@link #contentType(RDFSyntax)} or {@link #contentType(String)}
-	 * SHOULD be set before calling {@link #parse()}. 
+	 * SHOULD be set before calling {@link #parse()}.
 	 * <p>
 	 * The character set is assumed to be {@link StandardCharsets#UTF_8} unless
 	 * the {@link #contentType(String)} specifies otherwise or the document
-	 * declares its own charset (e.g. RDF/XML with a 
+	 * declares its own charset (e.g. RDF/XML with a
 	 * <code>&lt;?xml encoding="iso-8859-1"&gt;</code> header).
 	 * <p>
-	 * The {@link #base(IRI)} or {@link #base(String)} MAY be set before
-	 * calling {@link #parse()}, otherwise {@link Path#toUri()} will be used
-	 * as the base IRI.
+	 * The {@link #base(IRI)} or {@link #base(String)} MAY be set before calling
+	 * {@link #parse()}, otherwise {@link Path#toUri()} will be used as the base
+	 * IRI.
 	 * <p>
 	 * This method will override any source set with {@link #source(IRI)},
 	 * {@link #source(InputStream)} or {@link #source(String)}.
@@ -242,24 +238,23 @@ public interface RDFParserBuilder {
 	 * <p>
 	 * The source set will not be read before the call to {@link #parse()}.
 	 * <p>
-	 * If this builder does not support the given IRI 
-	 * (e.g. <code>urn:uuid:ce667463-c5ab-4c23-9b64-701d055c4890</code>),
-	 * this method should succeed, while the {@link #parse()} should 
-	 * throw an {@link IOException}. 
+	 * If this builder does not support the given IRI (e.g.
+	 * <code>urn:uuid:ce667463-c5ab-4c23-9b64-701d055c4890</code>), this method
+	 * should succeed, while the {@link #parse()} should throw an
+	 * {@link IOException}.
 	 * <p>
-	 * The {@link #contentType(RDFSyntax)} or {@link #contentType(String)}
-	 * MAY be set before calling {@link #parse()}, in which case that
-	 * type MAY be used for content negotiation (e.g. <code>Accept</code> header in HTTP),
+	 * The {@link #contentType(RDFSyntax)} or {@link #contentType(String)} MAY
+	 * be set before calling {@link #parse()}, in which case that type MAY be
+	 * used for content negotiation (e.g. <code>Accept</code> header in HTTP),
 	 * and SHOULD be used for selecting the RDFSyntax.
 	 * <p>
 	 * The character set is assumed to be {@link StandardCharsets#UTF_8} unless
-	 * the protocol's equivalent of <code>Content-Type</code> specifies otherwise or
-	 * the document declares its own charset (e.g. RDF/XML with a 
+	 * the protocol's equivalent of <code>Content-Type</code> specifies
+	 * otherwise or the document declares its own charset (e.g. RDF/XML with a
 	 * <code>&lt;?xml encoding="iso-8859-1"&gt;</code> header).
 	 * <p>
-	 * The {@link #base(IRI)} or {@link #base(String)} MAY be set before
-	 * calling {@link #parse()}, otherwise the source IRI will be used
-	 * as the base IRI.
+	 * The {@link #base(IRI)} or {@link #base(String)} MAY be set before calling
+	 * {@link #parse()}, otherwise the source IRI will be used as the base IRI.
 	 * <p>
 	 * This method will override any source set with {@link #source(Path)},
 	 * {@link #source(InputStream)} or {@link #source(String)}.
@@ -275,24 +270,23 @@ public interface RDFParserBuilder {
 	 * <p>
 	 * The source set will not be read before the call to {@link #parse()}.
 	 * <p>
-	 * If this builder does not support the given IRI 
-	 * (e.g. <code>urn:uuid:ce667463-c5ab-4c23-9b64-701d055c4890</code>),
-	 * this method should succeed, while the {@link #parse()} should 
-	 * throw an {@link IOException}. 
+	 * If this builder does not support the given IRI (e.g.
+	 * <code>urn:uuid:ce667463-c5ab-4c23-9b64-701d055c4890</code>), this method
+	 * should succeed, while the {@link #parse()} should throw an
+	 * {@link IOException}.
 	 * <p>
-	 * The {@link #contentType(RDFSyntax)} or {@link #contentType(String)}
-	 * MAY be set before calling {@link #parse()}, in which case that
-	 * type MAY be used for content negotiation (e.g. <code>Accept</code> header in HTTP),
+	 * The {@link #contentType(RDFSyntax)} or {@link #contentType(String)} MAY
+	 * be set before calling {@link #parse()}, in which case that type MAY be
+	 * used for content negotiation (e.g. <code>Accept</code> header in HTTP),
 	 * and SHOULD be used for selecting the RDFSyntax.
 	 * <p>
 	 * The character set is assumed to be {@link StandardCharsets#UTF_8} unless
-	 * the protocol's equivalent of <code>Content-Type</code> specifies otherwise or
-	 * the document declares its own charset (e.g. RDF/XML with a 
+	 * the protocol's equivalent of <code>Content-Type</code> specifies
+	 * otherwise or the document declares its own charset (e.g. RDF/XML with a
 	 * <code>&lt;?xml encoding="iso-8859-1"&gt;</code> header).
 	 * <p>
-	 * The {@link #base(IRI)} or {@link #base(String)} MAY be set before
-	 * calling {@link #parse()}, otherwise the source IRI will be used
-	 * as the base IRI.
+	 * The {@link #base(IRI)} or {@link #base(String)} MAY be set before calling
+	 * {@link #parse()}, otherwise the source IRI will be used as the base IRI.
 	 * <p>
 	 * This method will override any source set with {@link #source(Path)},
 	 * {@link #source(InputStream)} or {@link #source(IRI)}.
@@ -300,15 +294,35 @@ public interface RDFParserBuilder {
 	 * @param iri
 	 *            An IRI to retrieve and parse
 	 * @return An {@link RDFParserBuilder} that will use the specified source.
-	 */	
+	 */
 	RDFParserBuilder source(String iri);
 
 	/**
 	 * Parse the specified source.
+	 * <p>
+	 * A source method (e.g. {@link #source(InputStream)}, {@link #source(IRI)},
+	 * {@link #source(Path)}, {@link #source(String)} or an equivalent subclass
+	 * method) MUST have been called before calling this method, otherwise an
+	 * {@link IllegalStateException} will be thrown.
+	 * <p>
+	 * It is undefined if this method is thread-safe, however the
+	 * {@link RDFParserBuilder} may be reused (e.g. setting a different source)
+	 * as soon as the {@link Future} has been returned from this method.
+	 * <p>
+	 * The RDFParserBuilder SHOULD perform the parsing as an asynchronous
+	 * operation, and return the {@link Future} as soon as preliminary checks
+	 * (such as validity of the {@link #source(IRI)} and
+	 * {@link #contentType(RDFSyntax)} settings) have finished. The future
+	 * SHOULD not mark {@link Future#isDone()} before parsing is complete. A
+	 * synchronous implementation MAY be blocking on the <code>parse()</code>
+	 * call and return a Future that is already {@link Future#isDone()}.
+	 * <p>
+	 * If {@link #intoGraph(Graph)} has been specified, this SHOULD be the same
+	 * {@link Graph} instance returned from {@link Future#get() once parsing has
+	 * completed.
 	 * 
-	 * @return A Future that will return the graph containing (at least) the
-	 *         parsed triples.
-	 * 
+	 * @return A Future that will return the populated graph when the parsing
+	 *         has finished.
 	 * @throws IOException
 	 *             If an error occurred while reading the source.
 	 * @throws IllegalStateException

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
@@ -55,6 +55,12 @@ public interface RDFParserBuilder {
 	 * <p>
 	 * This option may be used together with {@link #intoGraph(Graph)} to
 	 * override the implementation's default factory and graph.
+	 * <p>
+	 * <strong>Warning:</strong> Using the same {@link RDFTermFactory} for 
+	 * multiple {@link #parse()} calls  may accidentally merge 
+	 * {@link BlankNode}s having the same label, as the parser may 
+	 * use the {@link RDFTermFactory#createBlankNode(String)} method
+	 * from the parsed blank node labels.
 	 * 
 	 * @see #intoGraph(Graph)
 	 * @param rdfTermFactory
@@ -323,13 +329,13 @@ public interface RDFParserBuilder {
 	 * call and return a Future that is already {@link Future#isDone()}.
 	 * <p>
 	 * If {@link #intoGraph(Graph)} has been specified, this SHOULD be the same
-	 * {@link Graph} instance returned from {@link Future#get() once parsing has
+	 * {@link Graph} instance returned from {@link Future#get()} once parsing has
 	 * completed successfully.
 	 * <p>
 	 * If an exception occurs during parsing, (e.g. {@link IOException} or
-	 * {@link java.text.ParseException}, it should be indicated as the
-	 * {@link java.util.concurrent.ExecutionException#getCause()) in the
-	 * {@link java.util.concurrent.ExecutionException) thrown on
+	 * {@link java.text.ParseException}), it should be indicated as the
+	 * {@link java.util.concurrent.ExecutionException#getCause()} in the
+	 * {@link java.util.concurrent.ExecutionException} thrown on
 	 * {@link Future#get()}.
 	 * 
 	 * @return A Future that will return the populated {@link Graph} when the
@@ -338,8 +344,8 @@ public interface RDFParserBuilder {
 	 *             If an error occurred while starting to read the source (e.g.
 	 *             file not found, unsupported IRI protocol). Note that IO
 	 *             errors during parsing would instead be the
-	 *             {@link java.util.concurrent.ExecutionException#getCause()) of
-	 *             the {@link java.util.concurrent.ExecutionException) thrown on
+	 *             {@link java.util.concurrent.ExecutionException#getCause()} of
+	 *             the {@link java.util.concurrent.ExecutionException} thrown on
 	 *             {@link Future#get()}.
 	 * @throws IllegalStateException
 	 *             If the builder is in an invalid state, e.g. a

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
@@ -19,10 +19,8 @@ package org.apache.commons.rdf.api;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Locale;
 import java.util.concurrent.Future;
 
 /**
@@ -126,7 +124,8 @@ public interface RDFParserBuilder {
 	 * <p>
 	 * The default if this option has not been set is that each call to
 	 * {@link #parse()} will return a new {@link Graph} (created using
-	 * {@link RDFTermFactory#createGraph() if #rdfTermFactory(RDFTermFactory)
+	 * {@link RDFTermFactory#createGraph()} 
+	 * if {@link #rdfTermFactory(RDFTermFactory)}
 	 * has been set).
 	 * 
 	 * @param graph
@@ -140,7 +139,7 @@ public interface RDFParserBuilder {
 	 * Specify a base IRI to use for parsing any relative IRI references.
 	 * <p>
 	 * Setting this option will override any protocol-specific base IRI (e.g.
-	 * <code>Content-Location</code> header) or the {@link #source(URL)} URL,
+	 * <code>Content-Location</code> header) or the {@link #source(IRI)} IRI,
 	 * but does not override any base IRIs set within the source document (e.g.
 	 * <code>@base</code> in Turtle documents).
 	 * <p>
@@ -161,7 +160,7 @@ public interface RDFParserBuilder {
 	 * Specify a base IRI to use for parsing any relative IRI references.
 	 * <p>
 	 * Setting this option will override any protocol-specific base IRI (e.g.
-	 * <code>Content-Location</code> header) or the {@link #source(URL)} URL,
+	 * <code>Content-Location</code> header) or the {@link #source(IRI)} IRI,
 	 * but does not override any base IRIs set within the source document (e.g.
 	 * <code>@base</code> in Turtle documents).
 	 * <p>

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
@@ -29,8 +29,16 @@ import java.util.concurrent.Future;
  * This interface follows the
  * <a href="https://en.wikipedia.org/wiki/Builder_pattern">Builder pattern</a>,
  * allowing to set parser settings like {@link #contentType(RDFSyntax)} and
- * {@link #base(IRI)}. A caller MUST call one of the {@link #source(IRI)}
- * methods before calling {@link #parse()} on the returned RDFParserBuilder.
+ * {@link #base(IRI)}. A caller MUST call one of the <code>source</code> methods
+ * (e.g. {@link #source(IRI)}, {@link #source(Path)},
+ * {@link #source(InputStream)}) before calling {@link #parse()} on the returned
+ * RDFParserBuilder - however methods can be called in any order.
+ * <p>
+ * Setting a method that has already been set will override any existing value
+ * in the returned builder - irregardless of the parameter type (e.g.
+ * {@link #source(IRI)} will override a previous {@link #source(Path)}. Settings
+ * can be unset by passing <code>null</code> - this may require casting, e.g.
+ * <code>contentType( (RDFSyntax) null )</code>.
  * <p>
  * It is undefined if a RDFParserBuilder is mutable or thread-safe, so callers
  * should always use the returned modified RDFParserBuilder from the builder

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 
 /**
  * Builder for parsing an RDF source into a Graph.
@@ -35,7 +36,7 @@ import java.util.concurrent.Future;
  * RDFParserBuilder - however methods can be called in any order.
  * <p>
  * The call to {@link #parse()} returns a {@link Future}, allowing asynchronous parse
- * operations. This can be combined with {@link #intoGraph(Graph)}
+ * operations. This can be combined with {@link #target(Graph)}
  * allowing access to the graph before parsing has completed,
  * however callers are still recommended to to check 
  * {@link Future#get()} for any exceptions thrown during parsing.
@@ -73,7 +74,7 @@ public interface RDFParserBuilder {
 	 * Specify which {@link RDFTermFactory} to use for generating
 	 * {@link RDFTerm}s.
 	 * <p>
-	 * This option may be used together with {@link #intoGraph(Graph)} to
+	 * This option may be used together with {@link #target(Graph)} to
 	 * override the implementation's default factory and graph.
 	 * <p>
 	 * <strong>Warning:</strong> Using the same {@link RDFTermFactory} for 
@@ -82,7 +83,7 @@ public interface RDFParserBuilder {
 	 * use the {@link RDFTermFactory#createBlankNode(String)} method
 	 * from the parsed blank node labels.
 	 * 
-	 * @see #intoGraph(Graph)
+	 * @see #target(Graph)
 	 * @param rdfTermFactory
 	 *            {@link RDFTermFactory} to use for generating RDFTerms.
 	 * @return An {@link RDFParserBuilder} that will use the specified
@@ -165,8 +166,12 @@ public interface RDFParserBuilder {
 	 * @return An {@link RDFParserBuilder} that will insert triples into the
 	 *         specified graph.
 	 */
-	RDFParserBuilder intoGraph(Graph graph);
+	default RDFParserBuilder target(Graph graph) {
+		return target(graph::add);
+	}
 
+	RDFParserBuilder target(Consumer<Triple> tripleConsumer);
+	
 	/**
 	 * Specify a base IRI to use for parsing any relative IRI references.
 	 * <p>
@@ -357,7 +362,7 @@ public interface RDFParserBuilder {
 	 * synchronous implementation MAY be blocking on the <code>parse()</code>
 	 * call and return a Future that is already {@link Future#isDone()}.
 	 * <p>
-	 * If {@link #intoGraph(Graph)} has been specified, this SHOULD be the same
+	 * If {@link #target(Graph)} has been specified, this SHOULD be the same
 	 * {@link Graph} instance returned from {@link Future#get()} once parsing has
 	 * completed successfully.
 	 * <p>

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
@@ -141,7 +141,7 @@ public interface RDFParserBuilder {
 	 *             If the contentType has an invalid syntax, or this
 	 *             RDFParserBuilder does not support the specified contentType.
 	 */
-	RDFParserBuilder contentType(String contentType);
+	RDFParserBuilder contentType(String contentType) throws IllegalArgumentException;
 
 	/**
 	 * Specify which {@link Graph} to add triples to.

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
@@ -1,0 +1,198 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Path;
+
+/**
+ * Builder for parsing an RDF source into a Graph.
+ * <p>
+ * This interface follows the
+ * <a href="https://en.wikipedia.org/wiki/Builder_pattern">Builder pattern</a>,
+ * allowing to set parser settings like {@link #contentType(RDFSyntax)} and
+ * {@link #base(IRI)}. A caller MUST at least call one of the
+ * <code>source</code> methods before calling {@link #parse()} on the returned
+ * RDFParserBuilder.
+ * <p>
+ * It is undefined if a RDFParserBuilder is mutable or thread-safe, callers
+ * should always use the returned modified RDFParserBuilder from the builder
+ * methods. The builder may return its own mutated instance, or a cloned builder
+ * with the modified setting.
+ * <p>
+ * Example usage:
+ * </p>
+ * 
+ * <pre>
+ *   Graph g1 = ExampleRDFParserBuilder.source("http://example.com/graph.rdf").parse();
+ *   ExampleRDFParserBuilder.source(Paths.get("/tmp/graph.ttl").contentType(RDFSyntax.TURTLE).intoGraph(g1).parse();
+ * </pre>
+ * 
+ *
+ */
+public interface RDFParserBuilder {
+
+	/**
+	 * Specify which {@link RDFTermFactory} to use for generating
+	 * {@link RDFTerm}s.
+	 * <p>
+	 * This option may be used together with {@link #intoGraph(Graph)} to
+	 * override the implementation's default factory and graph.
+	 * 
+	 * @see #intoGraph(Graph)
+	 * @param rdfTermFactory
+	 *            {@link RDFTermFactory} to use for generating RDFTerms.
+	 * @return An {@link RDFParserBuilder} that will use the specified
+	 *         rdfTermFactory
+	 */
+	RDFParserBuilder rdfTermFactory(RDFTermFactory rdfTermFactory);
+
+	/**
+	 * Specify the content type of the RDF syntax to parse.
+	 * <p>
+	 * This option can be used to select the RDFSyntax of the source, overriding
+	 * any <code>Content-Type</code> headers or equivalent.
+	 * <p>
+	 * If the content type is a 
+	 * <p>
+	 * This method will override any contentType set with
+	 * {@link #contentType(String)}.
+	 * 
+	 * @see #contentType(String)
+	 * @param rdfSyntax
+	 *            An {@link RDFSyntax} to parse the source according to, e.g.
+	 *            {@link RDFSyntax#TURTLE}.
+	 * @throws IllegalArgumentException
+	 *             If this RDFParserBuilder does not support the specified
+	 *             RDFSyntax.
+	 * @return An {@link RDFParserBuilder} that will use the specified content
+	 *         type.
+	 */
+	RDFParserBuilder contentType(RDFSyntax rdfSyntax) throws IllegalArgumentException;
+
+	/**
+	 * Specify the content type of the RDF syntax to parse.
+	 * <p>
+	 * This option can be used to select the RDFSyntax of the source, overriding
+	 * any <code>Content-Type</code> headers or equivalent.
+	 * <p>
+	 * This method will override any contentType set with
+	 * {@link #contentType(RDFSyntax)}.
+	 * 
+	 * @see #contentType(RDFSyntax)
+	 * @param contentType
+	 *            A content-type string, e.g. <code>text/turtle</code>
+	 * @throws IllegalArgumentException
+	 *             If this RDFParserBuilder does not support the specified
+	 *             content-type, or it has an invalid syntax.
+	 * @return An {@link RDFParserBuilder} that will use the specified content
+	 *         type.
+	 */
+	RDFParserBuilder contentType(String contentType);
+
+	/**
+	 * Specify which {@link Graph} to add triples into.
+	 * <p>
+	 * The default if this option has not been set is that 
+	 * each call to {@link #parse()} will return a new {@link Graph} (created using
+	 * {@link RDFTermFactory#createGraph() if #rdfTermFactory(RDFTermFactory)
+	 * has been set).
+	 * 
+	 * @param graph The {@link Graph} to add triples into.
+	 * @return An {@link RDFParserBuilder} that will insert triples into the specified graph.
+	 */
+	RDFParserBuilder intoGraph(Graph graph);
+
+	/**
+	 * Specify a base IRI to use for parsing any relative IRI references.
+	 * <p>
+	 * Setting this option will override any protocol-specific base IRI 
+	 * (e.g. <code>Content-Location</code> header) or the {@link #source(URL)} URL, 
+	 * but does not override any base IRIs set within the source document
+	 * (e.g. <code>@base</code> in Turtle documents).
+	 * <p>
+	 * If the source is in a syntax that does not support relative IRI references, 
+	 * e.g. {@link RDFSyntax#NTRIPLES}, setting the base has no effect.
+	 * <p>
+	 * This method will override any base IRI set with {@link #base(String)}.
+	 *
+	 * @see #base(String)
+	 * @param base An absolute IRI to use as a base
+	 * @return An {@link RDFParserBuilder} that will use the specified base IRI
+	 */
+	RDFParserBuilder base(IRI base);
+
+	/**
+	 * Specify a base IRI to use for parsing any relative IRI references.
+	 * <p>
+	 * Setting this option will override any protocol-specific base IRI 
+	 * (e.g. <code>Content-Location</code> header) or the {@link #source(URL)} URL, 
+	 * but does not override any base IRIs set within the source document
+	 * (e.g. <code>@base</code> in Turtle documents).
+	 * <p>
+	 * If the source is in a syntax that does not support relative IRI references, 
+	 * e.g. {@link RDFSyntax#NTRIPLES}, setting the base has no effect.
+	 * <p>
+	 * This method will override any base IRI set with {@link #base(IRI)}.
+	 *
+	 * @see #base(IRI)
+	 * @param base An absolute IRI to use as a base
+	 * @return An {@link RDFParserBuilder} that will use the specified base IRI
+	 */	
+	RDFParserBuilder base(String base);
+
+	/**
+	 * Specify a source to parse.
+	 * <p>
+	 * The source set will not be accessed before the call to {@link #parse()}. 
+	 * <p>
+	 * The InputStream will not be closed after parsing. The
+	 * InputStream does not need to support {@link InputStream#markSupported()}.
+	 * <p>
+	 * The {@link #contentType(RDFSyntax)} SHOULD be set unless the implementation
+	 * supports syntax guessing.
+	 * <p> 
+	 * The {@link #base(IRI)} MUST be set unless the syntax does not permit relative IRIs
+	 * (e.g.  {@link RDFSyntax#NTRIPLES}).
+	 * 
+	 * @param inputStream
+	 * @return
+	 */
+	RDFParserBuilder source(InputStream inputStream);
+
+	RDFParserBuilder source(Path file);
+
+	RDFParserBuilder source(IRI iri);
+
+	RDFParserBuilder source(String iri);
+
+	/**
+	 * Parse the specified source.
+	 * 
+	 * @return The graph containing (at least) the parsed triples.
+	 * 
+	 * @throws IOException
+	 *             If an error occurred while reading the source.
+	 * @throws IllegalStateException
+	 *             If the builder is in an invalid state, e.g. a
+	 *             <code>source</code> has not been set.
+	 */
+	Graph parse() throws IOException, IllegalStateException;
+}

--- a/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFParserBuilder.java
@@ -109,11 +109,11 @@ public interface RDFParserBuilder {
 	 *            or <code>text/turtle;charset="UTF-8"</code> as specified by
 	 *            <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">
 	 *            RFC7231</a>.
+	 * @return An {@link RDFParserBuilder} that will use the specified content
+	 *         type.
 	 * @throws IllegalArgumentException
 	 *             If the contentType has an invalid syntax, or this
 	 *             RDFParserBuilder does not support the specified contentType.
-	 * @return An {@link RDFParserBuilder} that will use the specified content
-	 *         type.
 	 */
 	RDFParserBuilder contentType(String contentType);
 
@@ -171,8 +171,10 @@ public interface RDFParserBuilder {
 	 * @param base
 	 *            An absolute IRI to use as a base.
 	 * @return An {@link RDFParserBuilder} that will use the specified base IRI.
+	 * @throws IllegalArgumentException
+	 *             If the base is not a valid absolute IRI string
 	 */
-	RDFParserBuilder base(String base);
+	RDFParserBuilder base(String base) throws IllegalArgumentException;
 
 	/**
 	 * Specify a source {@link InputStream} to parse.
@@ -294,8 +296,11 @@ public interface RDFParserBuilder {
 	 * @param iri
 	 *            An IRI to retrieve and parse
 	 * @return An {@link RDFParserBuilder} that will use the specified source.
+	 * @throws IllegalArgumentException
+	 *             If the base is not a valid absolute IRI string
+	 * 
 	 */
-	RDFParserBuilder source(String iri);
+	RDFParserBuilder source(String iri) throws IllegalArgumentException;
 
 	/**
 	 * Parse the specified source.
@@ -319,12 +324,23 @@ public interface RDFParserBuilder {
 	 * <p>
 	 * If {@link #intoGraph(Graph)} has been specified, this SHOULD be the same
 	 * {@link Graph} instance returned from {@link Future#get() once parsing has
-	 * completed.
+	 * completed successfully.
+	 * <p>
+	 * If an exception occurs during parsing, (e.g. {@link IOException} or
+	 * {@link java.text.ParseException}, it should be indicated as the
+	 * {@link java.util.concurrent.ExecutionException#getCause()) in the
+	 * {@link java.util.concurrent.ExecutionException) thrown on
+	 * {@link Future#get()}.
 	 * 
-	 * @return A Future that will return the populated graph when the parsing
-	 *         has finished.
+	 * @return A Future that will return the populated {@link Graph} when the
+	 *         parsing has finished.
 	 * @throws IOException
-	 *             If an error occurred while reading the source.
+	 *             If an error occurred while starting to read the source (e.g.
+	 *             file not found, unsupported IRI protocol). Note that IO
+	 *             errors during parsing would instead be the
+	 *             {@link java.util.concurrent.ExecutionException#getCause()) of
+	 *             the {@link java.util.concurrent.ExecutionException) thrown on
+	 *             {@link Future#get()}.
 	 * @throws IllegalStateException
 	 *             If the builder is in an invalid state, e.g. a
 	 *             <code>source</code> has not been set.

--- a/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.text.ParseException;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -55,6 +54,25 @@ import org.apache.commons.rdf.api.RDFTermFactory;
  */
 public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Cloneable {
 
+	public class RDFParseException extends Exception {		
+		private static final long serialVersionUID = 5427752643780702976L;
+		public RDFParseException() {
+			super();
+		}
+		public RDFParseException(String message, Throwable cause) {
+			super(message, cause);
+		}
+		public RDFParseException(String message) {
+			super(message);
+		}
+		public RDFParseException(Throwable cause) {
+			super(cause);
+		}
+		public RDFParserBuilder getRDFParserBuilder() {
+			return AbstractRDFParserBuilder.this;
+		}
+	}
+	
 	public static final ThreadGroup threadGroup = new ThreadGroup("Commons RDF parsers");
 	private static final ExecutorService threadpool = Executors.newCachedThreadPool(r -> new Thread(threadGroup, r));
 
@@ -321,9 +339,9 @@ public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Clon
 	 * <p>
 	 * 
 	 * @throws IOException If the source could not be read 
-	 * @throws ParseException If the source could not be parsed (e.g. a .ttl file was not valid Turtle)
+	 * @throws RDFParseException If the source could not be parsed (e.g. a .ttl file was not valid Turtle)
 	 */
-	protected abstract void parseSynchronusly() throws IOException, ParseException;
+	protected abstract void parseSynchronusly() throws IOException, RDFParseException;
 
 	/**
 	 * Prepare a clone of this RDFParserBuilder which have been checked and

--- a/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
@@ -361,8 +361,49 @@ public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Clon
 			URI baseUri = c.sourceFile.get().toRealPath().toUri();
 			c.base = Optional.of(internalRdfTermFactory.createIRI(baseUri.toString()));
 		}
+
 		return c;
 	}
+
+	/**
+	 * Guess RDFSyntax from a local file's extension.
+	 * <p>
+	 * This method can be used by subclasses if {@link #getContentType()} is not
+	 * present and {@link #getSourceFile()} is set.
+	 * 
+	 * @param path Path which extension should be checked
+	 * @return The {@link RDFSyntax} which has a matching {@link RDFSyntax#fileExtension}, 
+	 * 	otherwise {@link Optional#empty()}. 
+	 */
+	protected static Optional<RDFSyntax> guessRDFSyntax(Path path) {
+			return fileExtension(path).flatMap(RDFSyntax::byFileExtension);
+	}
+
+	/**
+	 * Return the file extension of a Path - if any.
+	 * <p>
+	 * The returned file extension includes the leading <code>.</code>
+	 * <p>
+	 * Note that this only returns the last extension, e.g. the 
+	 * file extension for <code>archive.tar.gz</code> would be <code>.gz</code>
+	 * 
+	 * @param path Path which filename might contain an extension
+	 * @return File extension (including the leading <code>.</code>, 
+	 * 	or {@link Optional#empty()} if the path has no extension
+	 */
+	private static Optional<String> fileExtension(Path path) {
+		Path fileName = path.getFileName();
+		if (fileName == null) { 
+			return Optional.empty();
+		}
+		String filenameStr = fileName.toString();
+		int last = filenameStr.lastIndexOf(".");
+		if (last > -1) { 
+			return Optional.of(filenameStr.substring(last));				
+		}
+		return Optional.empty();
+	}
+	
 
 	/**
 	 * Create a new {@link RDFTermFactory} for a parse session.

--- a/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
@@ -180,7 +180,7 @@ public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Clon
 	}
 
 	@Override
-	public RDFParserBuilder contentType(String contentType) {
+	public RDFParserBuilder contentType(String contentType) throws IllegalArgumentException {
 		AbstractRDFParserBuilder c = clone();
 		c.contentType = Optional.ofNullable(contentType);
 		c.contentTypeSyntax = c.contentType.flatMap(RDFSyntax::byMediaType);
@@ -344,6 +344,7 @@ public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Clon
 	protected AbstractRDFParserBuilder prepareForParsing() throws IOException, IllegalStateException {
 		checkSource();
 		checkBaseRequired();
+		checkContentType();
 		// We'll make a clone of our current state which will be passed to
 		// parseSynchronously()
 		AbstractRDFParserBuilder c = clone();
@@ -364,6 +365,17 @@ public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Clon
 		}
 
 		return c;
+	}
+	
+	/**
+	 * Subclasses can override this method to check compatibility with the
+	 * contentType setting.
+	 * 
+	 * @throws IllegalStateException
+	 *             if the {@link #getContentType()} or
+	 *             {@link #getContentTypeSyntax()} is not compatible or invalid
+	 */
+	protected void checkContentType() throws IllegalStateException {
 	}
 
 	/**

--- a/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
@@ -258,9 +258,12 @@ public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Clon
 	 * Check that one and only one source is present and valid.
 	 * <p>
 	 * Used by {@link #parse()}.
+	 * <p>
+	 * Subclasses might override this method, e.g. to support other
+	 * source combinations, or to check if the sourceIri is 
+	 * resolvable. 
 	 * 
-	 * @param iri
-	 * @throws IOException
+	 * @throws IOException If a source file can't be read
 	 */
 	protected void checkSource() throws IOException {
 		if (!sourceFile.isPresent() && !sourceInputStream.isPresent() && !sourceIri.isPresent()) {

--- a/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
@@ -1,0 +1,393 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.simple;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.ParseException;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.apache.commons.rdf.api.Graph;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDFParserBuilder;
+import org.apache.commons.rdf.api.RDFSyntax;
+import org.apache.commons.rdf.api.RDFTermFactory;
+
+/**
+ * Abstract RDFParserBuilder
+ * <p>
+ * This abstract class keeps the builder properties in protected fields like
+ * {@link #sourceFile} using {@link Optional}. Some basic checking like
+ * {@link #checkIsAbsolute(IRI)} is performed.
+ * <p>
+ * This class and its subclasses are {@link Cloneable}, immutable and
+ * (therefore) thread-safe - each call to option methods like
+ * {@link #contentType(String)} or {@link #source(IRI)} will return a cloned,
+ * mutated copy.
+ * <p>
+ * By default, parsing is done by the abstract method
+ * {@link #parseSynchronusly()} - which is executed in a cloned snapshot - hence
+ * multiple {@link #parse()} calls are thread-safe. The default {@link #parse()}
+ * uses a thread pool in {@link #threadGroup} - but implementations can override
+ * {@link #parse()} (e.g. because it has its own threading model or use
+ * asynchronou  remote execution).
+ */
+public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Cloneable {
+
+	public static final ThreadGroup threadGroup = new ThreadGroup("Commons RDF parsers");
+	private static final ExecutorService threadpool = Executors.newCachedThreadPool(r -> new Thread(threadGroup, r));
+
+	// Basically only used for creating IRIs
+	private static RDFTermFactory internalRdfTermFactory = new SimpleRDFTermFactory();
+
+	/**
+	 * Get the set {@link RDFTermFactory}, if any.
+	 */
+	public Optional<RDFTermFactory> getRdfTermFactory() {
+		return rdfTermFactory;
+	}
+
+	/**
+	 * Get the set content-type {@link RDFSyntax}, if any.
+	 * <p>
+	 * If this is {@link Optional#isPresent()}, then 
+	 * {@link #getContentType()} contains the 
+	 * value of {@link RDFSyntax#mediaType}. 
+	 */
+	public Optional<RDFSyntax> getContentTypeSyntax() {
+		return contentTypeSyntax;
+	}
+	
+	/**
+	 * Get the set content-type String, if any.
+	 * <p>
+	 * If this is {@link Optional#isPresent()} and 
+	 * is recognized by {@link RDFSyntax#byMediaType(String)}, then
+	 * the corresponding {@link RDFSyntax} is set on 
+	 * {@link #getContentType()}, otherwise that is
+	 * {@link Optional#empty()}. 
+	 */
+	public final Optional<String> getContentType() {
+		return contentType;
+	}
+
+	/**
+	 * Get the set {@link Graph} to insert into, if any.
+	 * <p>
+	 * From the call to {@link #parseSynchronusly()}, this
+	 * method is always {@link Optional#isPresent()}
+	 * with a new {@link Graph} instance, and 
+	 * will be the value returned from {@link #parse()}.
+	 */	
+	public Optional<Graph> getIntoGraph() {
+		return intoGraph;
+	}
+
+	/**
+	 * Get the set base {@link IRI}, if present.
+	 * <p>
+	 * 
+	 */	
+	public Optional<IRI> getBase() {
+		return base;
+	}
+
+	/**
+	 * Get the set source {@link InputStream}.
+	 * <p>
+	 * If this is {@link Optional#isPresent()}, then 
+	 * {@link #getSourceFile()} and {@link #getSourceIri()}
+	 * are {@link Optional#empty()}.
+	 */
+	public Optional<InputStream> getSourceInputStream() {
+		return sourceInputStream;
+	}
+
+	/**
+	 * Get the set source {@link Path}.
+	 * <p>
+	 * If this is {@link Optional#isPresent()}, then 
+	 * {@link #getSourceInputStream()} and {@link #getSourceIri()}
+	 * are {@link Optional#empty()}.
+	 */	
+	public Optional<Path> getSourceFile() {
+		return sourceFile;
+	}
+
+	/**
+	 * Get the set source {@link Path}.
+	 * <p>
+	 * If this is {@link Optional#isPresent()}, then 
+	 * {@link #getSourceInputStream()} and {@link #getSourceInputStream()()}
+	 * are {@link Optional#empty()}.
+	 */		
+	public Optional<IRI> getSourceIri() {
+		return sourceIri;
+	}
+
+	private Optional<RDFTermFactory> rdfTermFactory = Optional.empty();
+	private Optional<RDFSyntax> contentTypeSyntax = Optional.empty();
+	private Optional<String> contentType = Optional.empty();
+	private Optional<Graph> intoGraph = Optional.empty();
+	private Optional<IRI> base = Optional.empty();
+	private Optional<InputStream> sourceInputStream = Optional.empty();
+	private Optional<Path> sourceFile = Optional.empty();
+	private Optional<IRI> sourceIri = Optional.empty();
+
+	@Override
+	public AbstractRDFParserBuilder clone() {
+		try {
+			return (AbstractRDFParserBuilder) super.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public RDFParserBuilder rdfTermFactory(RDFTermFactory rdfTermFactory) {
+		AbstractRDFParserBuilder c = clone();
+		c.rdfTermFactory = Optional.ofNullable(rdfTermFactory);
+		return c;
+	}
+
+	@Override
+	public RDFParserBuilder contentType(RDFSyntax rdfSyntax) throws IllegalArgumentException {
+		AbstractRDFParserBuilder c = clone();
+		c.contentTypeSyntax = Optional.ofNullable(rdfSyntax);
+		c.contentType = c.contentTypeSyntax.map(syntax -> syntax.mediaType);
+		return c;
+	}
+
+	@Override
+	public RDFParserBuilder contentType(String contentType) {
+		AbstractRDFParserBuilder c = clone();
+		c.contentType = Optional.ofNullable(contentType);
+		c.contentTypeSyntax = c.contentType.flatMap(RDFSyntax::byMediaType);
+		return c;
+	}
+
+	@Override
+	public RDFParserBuilder intoGraph(Graph graph) {
+		AbstractRDFParserBuilder c = clone();
+		c.intoGraph = Optional.ofNullable(graph);
+		return c;
+	}
+
+	@Override
+	public RDFParserBuilder base(IRI base) {
+		AbstractRDFParserBuilder c = clone();
+		c.base = Optional.ofNullable(base);
+		c.base.ifPresent(i -> checkIsAbsolute(i));
+		return c;
+	}
+
+	@Override
+	public RDFParserBuilder base(String base) throws IllegalArgumentException {
+		return base(internalRdfTermFactory.createIRI(base));
+	}
+
+	@Override
+	public RDFParserBuilder source(InputStream inputStream) {
+		AbstractRDFParserBuilder c = clone();
+		c.resetSource();
+		c.sourceInputStream = Optional.ofNullable(inputStream);
+		return c;
+	}
+
+	@Override
+	public RDFParserBuilder source(Path file) {
+		AbstractRDFParserBuilder c = clone();
+		c.resetSource();
+		c.sourceFile = Optional.ofNullable(file);
+		return c;
+	}
+
+	@Override
+	public RDFParserBuilder source(IRI iri) {
+		AbstractRDFParserBuilder c = clone();
+		c.resetSource();
+		c.sourceIri = Optional.ofNullable(iri);
+		c.sourceIri.ifPresent(i -> checkIsAbsolute(i));
+		return c;
+	}
+
+	@Override
+	public RDFParserBuilder source(String iri) throws IllegalArgumentException {
+		AbstractRDFParserBuilder c = clone();
+		c.resetSource();
+		c.sourceIri = Optional.ofNullable(iri).map(internalRdfTermFactory::createIRI);
+		c.sourceIri.ifPresent(i -> checkIsAbsolute(i));
+		return source(internalRdfTermFactory.createIRI(iri));
+	}
+
+	/**
+	 * Check if an iri is absolute.
+	 * <p>
+	 * Used by {@link #source(String)} and {@link #base(String)}
+	 * 
+	 * @param iri
+	 */
+	protected void checkIsAbsolute(IRI iri) {
+		if (!URI.create(iri.getIRIString()).isAbsolute()) {
+			throw new IllegalArgumentException("IRI is not absolute: " + iri);
+		}
+	}
+
+	/**
+	 * Check that one and only one source is present and valid.
+	 * <p>
+	 * Used by {@link #parse()}.
+	 * 
+	 * @param iri
+	 * @throws IOException
+	 */
+	protected void checkSource() throws IOException {
+		if (!sourceFile.isPresent() && !sourceInputStream.isPresent() && !sourceIri.isPresent()) {
+			throw new IllegalStateException("No source has been set");
+		}
+		if (sourceIri.isPresent() && sourceInputStream.isPresent()) {
+			throw new IllegalStateException("Both sourceIri and sourceInputStream have been set");
+		}
+		if (sourceIri.isPresent() && sourceFile.isPresent()) {
+			throw new IllegalStateException("Both sourceIri and sourceFile have been set");
+		}
+		if (sourceInputStream.isPresent() && sourceFile.isPresent()) {
+			throw new IllegalStateException("Both sourceInputStream and sourceFile have been set");
+		}
+		if (sourceFile.isPresent() && !sourceFile.filter(Files::isReadable).isPresent()) {
+			throw new IOException("Can't read file: " + sourceFile);
+		}
+	}
+
+	/**
+	 * Check if base is required.
+	 * 
+	 * @throws IllegalStateException if base is required, but not set.
+	 */
+	protected void checkBaseRequired() {
+		if (!base.isPresent() && sourceInputStream.isPresent()
+				&& !contentTypeSyntax.filter(t -> t == RDFSyntax.NQUADS || t == RDFSyntax.NTRIPLES).isPresent()) {
+			throw new IllegalStateException("base iri required for inputstream source");
+		}
+	}
+
+	/**
+	 * Reset all source* fields to Optional.empty()
+	 * <p>
+	 * Subclasses should override this and call <code>super.resetSource()</code>
+	 * if they need to reset any additional source* fields.
+	 * 
+	 */
+	protected void resetSource() {
+		sourceInputStream = Optional.empty();
+		sourceIri = Optional.empty();
+		sourceFile = Optional.empty();
+	}
+
+	/**
+	 * Parse {@link #sourceInputStream}, {@link #sourceFile} or
+	 * {@link #sourceIri}.
+	 * <p>
+	 * One of the source fields MUST be present, as checked by {@link #checkSource()}.
+	 * <p>
+	 * {@link #checkBaseRequired()} is called to verify if {@link #getBase()} is required.
+	 * <p>
+	 * When this method is called, {@link #intoGraph} MUST always be present, as
+	 * that is where the parsed triples MUST be inserted into.
+	 * <p>
+	 * 
+	 * @return
+	 * @throws IOException
+	 * @throws IllegalStateException
+	 * @throws ParseException
+	 */
+	protected abstract void parseSynchronusly() throws IOException, IllegalStateException, ParseException;
+
+	/**
+	 * Prepare a clone of this RDFParserBuilder which have been checked and
+	 * completed.
+	 * <p>
+	 * The returned clone will always have
+	 * {@link #getIntoGraph()} and {@link #getRdfTermFactory()} present.
+	 * <p>
+	 * If the {@link #getSourceFile()} is present, but the 
+	 * {@link #getBase()} is not present, the base will be set to the
+	 * <code>file:///</code> IRI for the Path's real path (e.g. resolving any 
+	 * symbolic links).  
+	 *  
+	 * @return
+	 * @throws IOException
+	 * @throws IllegalStateException
+	 */
+	protected AbstractRDFParserBuilder prepareForParsing() throws IOException, IllegalStateException {
+		checkSource();
+		checkBaseRequired();
+		// We'll make a clone of our current state which will be passed to
+		// parseSynchronously()
+		AbstractRDFParserBuilder c = clone();
+
+		// Use a fresh SimpleRDFTermFactory for each parse
+		if (!c.rdfTermFactory.isPresent()) {
+			c.rdfTermFactory = Optional.of(createRDFTermFactory());
+		}
+		// No graph? We'll create one.
+		if (!c.intoGraph.isPresent()) {
+			c.intoGraph = c.rdfTermFactory.map(RDFTermFactory::createGraph);
+		}
+		// sourceFile, but no base? Let's follow any symlinks and use
+		// the file:/// URI
+		if (c.sourceFile.isPresent() && !c.base.isPresent()) {
+			URI baseUri = c.sourceFile.get().toRealPath().toUri();
+			c.base = Optional.of(internalRdfTermFactory.createIRI(baseUri.toString()));
+		}
+		return c;
+	}
+
+	/**
+	 * Create a new {@link RDFTermFactory} for a parse session.
+	 * <p>
+	 * This is called by {@link #parse()} to set 
+	 * {@link #rdfTermFactory(RDFTermFactory)} if it is
+	 * {@link Optional#empty()}, and therefore used also for 
+	 * creating a new {@link Graph} if 
+	 * {@link #getIntoGraph()} is {@link Optional#empty()}.
+	 * <p>
+	 * 
+	 * 
+	 * @return
+	 */
+	protected RDFTermFactory createRDFTermFactory() {
+		return new SimpleRDFTermFactory();
+	}
+
+	@Override
+	public Future<Graph> parse() throws IOException, IllegalStateException {
+		final AbstractRDFParserBuilder c = prepareForParsing();
+		return threadpool.submit(() -> {
+			c.parseSynchronusly();
+			return c.intoGraph.get();
+		});
+	}
+
+}

--- a/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.java
@@ -317,12 +317,10 @@ public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Clon
 	 * that is where the parsed triples MUST be inserted into.
 	 * <p>
 	 * 
-	 * @return
-	 * @throws IOException
-	 * @throws IllegalStateException
-	 * @throws ParseException
+	 * @throws IOException If the source could not be read 
+	 * @throws ParseException If the source could not be parsed (e.g. a .ttl file was not valid Turtle)
 	 */
-	protected abstract void parseSynchronusly() throws IOException, IllegalStateException, ParseException;
+	protected abstract void parseSynchronusly() throws IOException, ParseException;
 
 	/**
 	 * Prepare a clone of this RDFParserBuilder which have been checked and
@@ -336,9 +334,9 @@ public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Clon
 	 * <code>file:///</code> IRI for the Path's real path (e.g. resolving any 
 	 * symbolic links).  
 	 *  
-	 * @return
-	 * @throws IOException
-	 * @throws IllegalStateException
+	 * @return A completed and checked clone of this RDFParserBuilder
+	 * @throws IOException If the source was not accessible (e.g. a file was not found)
+	 * @throws IllegalStateException If the parser was not in a compatible setting (e.g. contentType was an invalid string) 
 	 */
 	protected AbstractRDFParserBuilder prepareForParsing() throws IOException, IllegalStateException {
 		checkSource();
@@ -414,9 +412,12 @@ public abstract class AbstractRDFParserBuilder implements RDFParserBuilder, Clon
 	 * creating a new {@link Graph} if 
 	 * {@link #getIntoGraph()} is {@link Optional#empty()}.
 	 * <p>
+	 * As parsed blank nodes might be made with 
+	 * {@link RDFTermFactory#createBlankNode(String)}, 
+	 * each call to this method should return 
+	 * a new RDFTermFactory instance.
 	 * 
-	 * 
-	 * @return
+	 * @return A new {@link RDFTermFactory}
 	 */
 	protected RDFTermFactory createRDFTermFactory() {
 		return new SimpleRDFTermFactory();

--- a/simple/src/test/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilderTest.java
+++ b/simple/src/test/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilderTest.java
@@ -19,9 +19,11 @@ package org.apache.commons.rdf.simple;
 
 import static org.junit.Assert.*;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.rdf.api.Graph;
@@ -29,39 +31,211 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Literal;
 import org.apache.commons.rdf.api.RDFParserBuilder;
 import org.apache.commons.rdf.api.RDFSyntax;
+import org.apache.commons.rdf.api.RDFTerm;
+import org.apache.commons.rdf.api.RDFTermFactory;
 import org.apache.commons.rdf.api.Triple;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class AbstractRDFParserBuilderTest {
 
-	/**
-	 * Test a basic parsing of an N-Triples-file
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void parseFile() throws Exception {		
-		Path file = Files.createTempFile("test", ".nt");
-		// No need to populate the file as the dummy parser
+	private RDFTermFactory factory = new SimpleRDFTermFactory();
+	
+	private DummyRDFParserBuilder dummyParser = new DummyRDFParserBuilder();
+	private Path testNt;
+	private Path testTtl;
+	private Path testXml;
+
+	@Before
+	public void createTempFile() throws IOException {
+		testNt = Files.createTempFile("test", ".nt");
+		testTtl = Files.createTempFile("test", ".ttl");
+		testXml = Files.createTempFile("test", ".xml");
+
+		// No need to populate the files as the dummy parser
 		// doesn't actually read anything
-		
-		RDFParserBuilder parser = new DummyRDFParserBuilder()
-				.source(file).contentType(RDFSyntax.NTRIPLES);
-		Future<Graph> f = parser.parse();
-		Graph g = f.get(5, TimeUnit.SECONDS);
-		
-		assertEquals(1, g.size());
-		Triple triple = g.getTriples().findAny().get();
+	}
+
+	@After
+	public void deleteTempFiles() throws IOException {
+		Files.deleteIfExists(testNt);
+		Files.deleteIfExists(testTtl);
+		Files.deleteIfExists(testXml);
+	}
+
+	@Test
+	public void guessRDFSyntax() throws Exception {
+		assertEquals(RDFSyntax.NTRIPLES, AbstractRDFParserBuilder.guessRDFSyntax(testNt).get());
+		assertEquals(RDFSyntax.TURTLE, AbstractRDFParserBuilder.guessRDFSyntax(testTtl).get());
+		assertFalse(AbstractRDFParserBuilder.guessRDFSyntax(testXml).isPresent());
+	}
+
+	private void checkGraph(Graph g) throws Exception {				
+		assertTrue(g.size() > 0);		
+		IRI greeting = factory.createIRI("http://example.com/greeting");	
+		// Should only have parsed once!
+		assertEquals(1, g.getTriples(null, greeting, null).count());
+		Triple triple = g.getTriples(null, greeting, null).findAny().get();
 		assertTrue(triple.getSubject() instanceof IRI);
-		IRI iri = (IRI)triple.getSubject();
-		assertEquals("http://example.com/test1", iri.getIRIString());
-		
+		IRI parsing = (IRI) triple.getSubject();
+		assertTrue(parsing.getIRIString().startsWith("urn:uuid:"));
+
 		assertEquals("http://example.com/greeting", triple.getPredicate().getIRIString());
-		
+
 		assertTrue(triple.getObject() instanceof Literal);
-		Literal literal = (Literal)triple.getObject();
+		Literal literal = (Literal) triple.getObject();
 		assertEquals("Hello world", literal.getLexicalForm());
 		assertFalse(literal.getLanguageTag().isPresent());
 		assertEquals(Types.XSD_STRING, literal.getDatatype());
+		
+		// Check uniqueness of properties that are always present
+		assertEquals(1, 
+				g.getTriples(null, factory.createIRI("http://example.com/source"), null).count());
+		
+		// Check optional properties that are unique
+		assertTrue(2 > g.getTriples(null, factory.createIRI("http://example.com/base"), null).count());
+		assertTrue(2 > g.getTriples(null, factory.createIRI("http://example.com/contentType"), null).count());
+		assertTrue(2 > g.getTriples(null, factory.createIRI("http://example.com/contentTypeSyntax"), null).count());
 	}
+	
+	@Test
+	public void parseFile() throws Exception {
+		RDFParserBuilder parser = dummyParser.source(testNt);
+		Graph g = parser.parse().get(5, TimeUnit.SECONDS);
+		checkGraph(g);
+		// FIXME: this could potentially break if the equivalent of /tmp includes
+		// international characters
+		assertEquals("<" + testNt.toUri().toString() + ">", firstPredicate(g, "source"));
+		// Should be set to the file path
+		assertEquals("<" + testNt.toUri().toString() + ">", firstPredicate(g, "base"));		
+
+		// Should NOT have guessed the content type
+		assertNull(firstPredicate(g, "contentType"));
+		assertNull(firstPredicate(g, "contentTypeSyntax"));
+	}
+
+
+	@Test
+	public void parseNoSource() throws Exception {
+		thrown.expect(IllegalStateException.class);
+		dummyParser.parse();		
+	}
+	
+	@Test
+	public void parseBaseAndContentTypeNoSource() throws Exception {
+		// Can set the other options, even without source()
+		IRI base = dummyParser.createRDFTermFactory().createIRI("http://www.example.org/test.rdf");
+		RDFParserBuilder parser = dummyParser.base(base).contentType(RDFSyntax.RDFXML);
+		thrown.expect(IllegalStateException.class);
+		thrown.expectMessage("No source has been set");
+		// but .parse() should fail
+		parser.parse();		
+	}
+	
+	@Test
+	public void parseFileMissing() throws Exception {
+		Files.delete(testNt);
+		// This should not fail yet
+		RDFParserBuilder parser = dummyParser.source(testNt);
+		// but here:
+		thrown.expect(IOException.class);
+		parser.parse();		
+	}
+
+	
+	@Test
+	public void parseFileContentType() throws Exception {
+		RDFParserBuilder parser = dummyParser.source(testNt).contentType(RDFSyntax.NTRIPLES);
+		Graph g = parser.parse().get(5, TimeUnit.SECONDS);
+		checkGraph(g);
+		// FIXME: this could potentially break if the equivalent of /tmp includes
+		// international characters
+		assertEquals("<" + testNt.toUri().toString() + ">", firstPredicate(g, "source"));
+		assertEquals("<" + testNt.toUri().toString() + ">", firstPredicate(g, "base"));		
+		assertEquals("\"NTRIPLES\"", firstPredicate(g, "contentTypeSyntax"));
+		assertEquals("\"application/n-triples\"", firstPredicate(g, "contentType"));
+	}
+
+	private String firstPredicate(Graph g, String pred) {
+		return g.getTriples(null, factory.createIRI("http://example.com/" + pred), null)
+				.map(Triple::getObject).map(RDFTerm::ntriplesString).findAny().orElse(null);
+	}
+
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+	
+	@Test
+	public void parseInputStreamFailsIfBaseMissing() throws Exception {
+		InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+		// Should not fail at this point
+		RDFParserBuilder parser = dummyParser.source(inputStream);
+		// but here:
+		thrown.expect(IllegalStateException.class);
+		thrown.expectMessage("base iri required for inputstream source");
+		parser.parse();
+	}
+
+	@Test
+	public void parseInputStreamWithBase() throws Exception {
+		InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+		IRI base = dummyParser.createRDFTermFactory().createIRI("http://www.example.org/test.rdf");
+		RDFParserBuilder parser = dummyParser.source(inputStream).base(base);		
+		Graph g = parser.parse().get(5, TimeUnit.SECONDS);
+		checkGraph(g);
+		assertEquals("<http://www.example.org/test.rdf>", firstPredicate(g, "base"));
+		// in our particular debug output, 
+		// bnode source indicates InputStream 
+		assertTrue(firstPredicate(g, "source").startsWith("_:"));
+		assertNull(firstPredicate(g, "contentType"));
+		assertNull(firstPredicate(g, "contentTypeSyntax"));
+	}
+	
+	@Test
+	public void parseInputStreamWithNQuads() throws Exception {
+		InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+		RDFParserBuilder parser = dummyParser.source(inputStream).contentType(RDFSyntax.NQUADS);		
+		Graph g = parser.parse().get(5, TimeUnit.SECONDS);
+		checkGraph(g);
+		assertNull(firstPredicate(g, "base"));
+		// in our particular debug output, 
+		// bnode source indicates InputStream 
+		assertTrue(firstPredicate(g, "source").startsWith("_:"));
+		assertEquals("\"application/n-quads\"", firstPredicate(g, "contentType"));
+		assertEquals("\"NQUADS\"", firstPredicate(g, "contentTypeSyntax"));
+	}	
+
+	@Test
+	public void parseIRI() throws Exception {
+		IRI iri = dummyParser.createRDFTermFactory().createIRI("http://www.example.net/test.ttl");
+		RDFParserBuilder parser = dummyParser.source(iri);		
+		Graph g = parser.parse().get(5, TimeUnit.SECONDS);
+		checkGraph(g);
+		assertEquals("<http://www.example.net/test.ttl>", firstPredicate(g, "source"));
+		// No base - assuming the above IRI is always 
+		// the base would break server-supplied base from 
+		// any HTTP Location redirects and  Content-Location header
+		assertNull(firstPredicate(g, "base"));
+		// ".ttl" in IRI string does not imply any content type
+		assertNull(firstPredicate(g, "contentType"));
+		assertNull(firstPredicate(g, "contentTypeSyntax"));
+		
+	}
+	
+	@Test
+	public void parseIRIBaseContentType() throws Exception {
+		IRI iri = dummyParser.createRDFTermFactory().createIRI("http://www.example.net/test.ttl");
+		RDFParserBuilder parser = dummyParser.source(iri).base(iri).contentType(RDFSyntax.TURTLE);
+		Graph g = parser.parse().get(5, TimeUnit.SECONDS);
+		checkGraph(g);
+		assertEquals("<http://www.example.net/test.ttl>", firstPredicate(g, "source"));
+		assertEquals("<http://www.example.net/test.ttl>", firstPredicate(g, "base"));
+		assertEquals("\"TURTLE\"", firstPredicate(g, "contentTypeSyntax"));
+		assertEquals("\"text/turtle\"", firstPredicate(g, "contentType"));
+	}
+
+	
 }

--- a/simple/src/test/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilderTest.java
+++ b/simple/src/test/java/org/apache/commons/rdf/simple/AbstractRDFParserBuilderTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.simple;
+
+import static org.junit.Assert.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.rdf.api.Graph;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Literal;
+import org.apache.commons.rdf.api.RDFParserBuilder;
+import org.apache.commons.rdf.api.RDFSyntax;
+import org.apache.commons.rdf.api.Triple;
+import org.junit.Test;
+
+public class AbstractRDFParserBuilderTest {
+
+	/**
+	 * Test a basic parsing of an N-Triples-file
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void parseFile() throws Exception {		
+		Path file = Files.createTempFile("test", ".nt");
+		// No need to populate the file as the dummy parser
+		// doesn't actually read anything
+		
+		RDFParserBuilder parser = new DummyRDFParserBuilder()
+				.source(file).contentType(RDFSyntax.NTRIPLES);
+		Future<Graph> f = parser.parse();
+		Graph g = f.get(5, TimeUnit.SECONDS);
+		
+		assertEquals(1, g.size());
+		Triple triple = g.getTriples().findAny().get();
+		assertTrue(triple.getSubject() instanceof IRI);
+		IRI iri = (IRI)triple.getSubject();
+		assertEquals("http://example.com/test1", iri.getIRIString());
+		
+		assertEquals("http://example.com/greeting", triple.getPredicate().getIRIString());
+		
+		assertTrue(triple.getObject() instanceof Literal);
+		Literal literal = (Literal)triple.getObject();
+		assertEquals("Hello world", literal.getLexicalForm());
+		assertFalse(literal.getLanguageTag().isPresent());
+		assertEquals(Types.XSD_STRING, literal.getDatatype());
+	}
+}

--- a/simple/src/test/java/org/apache/commons/rdf/simple/DummyRDFParserBuilder.java
+++ b/simple/src/test/java/org/apache/commons/rdf/simple/DummyRDFParserBuilder.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.simple;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+import org.apache.commons.rdf.api.Graph;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Literal;
+import org.apache.commons.rdf.api.RDFParserBuilder;
+import org.apache.commons.rdf.api.RDFTermFactory;
+
+/** 
+ * For test purposes - a {@link RDFParserBuilder} that always insert a single triple.
+ * <p>
+ * This dummy RDF parser always sleeps for at least 1000 ms
+ * before inserting the triple:
+ * <pre>
+ *    <http://example.com/test1> <http://example.com/greeting> "Hello world" .
+ * </pre>
+ *
+ */
+public class DummyRDFParserBuilder extends AbstractRDFParserBuilder {
+
+	@Override
+	protected void parseSynchronusly() throws IOException, IllegalStateException, ParseException {		
+		// From parseSynchronusly both of these are always present
+		RDFTermFactory factory = getRdfTermFactory().get();
+		Graph graph = getIntoGraph().get();
+		
+		// Let's always insert the same triple
+		IRI test1 = factory.createIRI("http://example.com/test1");
+		IRI greeting = factory.createIRI("http://example.com/greeting");
+		Literal hello = factory.createLiteral("Hello world");
+		try {
+			// Pretend we take a while to parse
+			Thread.sleep(1000);			
+		} catch (InterruptedException e) {
+			return;
+		} 
+		graph.add(test1, greeting, hello); 		
+	}
+
+}

--- a/simple/src/test/java/org/apache/commons/rdf/simple/DummyRDFParserBuilder.java
+++ b/simple/src/test/java/org/apache/commons/rdf/simple/DummyRDFParserBuilder.java
@@ -46,7 +46,7 @@ import org.apache.commons.rdf.api.RDFTermFactory;
 public class DummyRDFParserBuilder extends AbstractRDFParserBuilder {
 	
 	@Override
-	protected void parseSynchronusly() throws IOException, IllegalStateException, ParseException {		
+	protected void parseSynchronusly() throws IOException, IllegalStateException, RDFParseException {		
 		// From parseSynchronusly both of these are always present
 		RDFTermFactory factory = getRdfTermFactory().get();
 		Graph graph = getIntoGraph().get();


### PR DESCRIPTION
This pull request proposes a `RDFParserBuilder` interface - a "Builder for parsing an RDF source into a Graph".

The javadocs explain the approach:

* http://stain.github.io/incubator-commonsrdf/rdfparserbuilder/org/apache/commons/rdf/api/RDFParserBuilder.html
* http://stain.github.io/incubator-commonsrdf/rdfparserbuilder/org/apache/commons/rdf/simple/AbstractRDFParserBuilder.html

`AbstractRDFParserBuilder` is here part of `simple` (but has no implementation in there as Simple has no parsers) - and basically takes care of handling the 'builder' aspect in an immutable way - but also does some more generic checking and thread handling which implementations may override.

It could be that these two aspects of AbstractRDFParserBuilder could be split, and a neutral bean-like builder abstract class could be added to `api`, and the more checker-helper-things to another abstract subclass in `simple`.


I think once we agree on the style it's easier to do the equivalent Writer interface - but feel free to contribute to the `parser-writer-interface` branch!

Example implementations:

- [jsonld branch](https://github.com/apache/incubator-commonsrdf/blob/jsonld-java/jsonld-java/src/main/java/org/apache/commons/rdf/jsonldjava/JsonLdParserBuilder.java)
- [stain/jena branch](https://github.com/stain/incubator-commonsrdf/blob/jena/jena/src/main/java/org/apache/commons/rdf/jena/JenaRDFParserBuilder.java)  (builds on Andy's https://github.com/afs/commonsrdf-jena)

Example usage:

```java
IRI iri = factory.createIRI("http://example.com/example.jsonld");
Graph g = new JsonLdParserBuilder()
				.contentType(RDFSyntax.JSONLD).source(iri).parse()
				.get(10, TimeUnit.SECONDS);
```

Some things to discuss:

- Should this merge the `quad` branch from #19 and add `intoDataset(Dataset)`?  Would the return type from `parse()` then be a `Future<GraphOrDataset>`? (Or would a `ParseResult` wrapper be better?)
- How can `RDFParserBuilder` implementations be discovered? Another `ServiceLoader`, or part of `RDFTermFactory` (which then need to change name to just `RDFFactory` ?)
- Should there be a kind of `canHandle(RDFSyntax)` method, or would you ask for the parser with `rdfFactory.getParser(RDFSyntax.JSONLD)` instead?  (Note: sometimes the content type is not known in advance, e.g. URIs on the internet)
- Should there be a concrete implementation that calls down to more lower-level parser interfaces? E.g. equivalent to Jena's `RDFDataMgr`?

Note - my branch with jsonld-java is a bit of an outlier as it's not a complete RDF framework and mainly does JSON-LD - however N-Quad and Turtle support is already part of jsonld-java - however I'm not sure if that is just for parsing or writing.  We would expect most of the bigger frameworks to do most of the standard syntaxes we enumerated in [RDFSyntax](https://commonsrdf.incubator.apache.org/apidocs/org/apache/commons/rdf/api/RDFSyntax.html)